### PR TITLE
Modyfikacja wielkości czcionek w AlgebraLiniowa

### DIFF
--- a/AlgebraLiniowa/source/conf.py
+++ b/AlgebraLiniowa/source/conf.py
@@ -1,6 +1,16 @@
 # -*- coding: utf-8 -*-
 import sys, os
 
+from sphinx.highlighting import PygmentsBridge
+from pygments.formatters.latex import LatexFormatter
+
+class CustomLatexFormatter(LatexFormatter):
+    def __init__(self, **options):
+        super(CustomLatexFormatter, self).__init__(**options)
+        self.verboptions = r"formatcom=\footnotesize"
+
+PygmentsBridge.latex_formatter = CustomLatexFormatter
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -163,10 +173,10 @@ latex_elements = {
 #'papersize': 'a4paper',
 
 # The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+'pointsize': '11pt',
 
 # Additional stuff for the LaTeX preamble.
-'preamble': '\usepackage{amsmath,amssymb}\n',
+'preamble': '\usepackage{amsmath,amssymb}\n' + '\makeatletter\n\g@addto@macro\@verbatim\\footnotesize\n\makeatother',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples


### PR DESCRIPTION
Modyfikacja na razie tylko w AlgebraLiniowa. Ustawiłem tekst na 11pt (było 10pt), natomiast verbatim na \footnotesize tj:

Command             10pt    11pt    12pt
\tiny               5       6       6
\scriptsize         7       8       8
\footnotesize       8       9       10
\small              9       10      10.95
\normalsize         10      10.95   12
\large              12      12      14.4
\Large              14.4    14.4    17.28
\LARGE              17.28   17.28   20.74
\huge               20.74   20.74   24.88
\Huge               24.88   24.88   24.88

Jeśli wielkości są ok to potem można zmienić w pozostałych oraz w skrypcie generującym projekt "iCSE sphinx".
