### PR TITLE
Stylowanie

### DIFF
--- a/AlgebraLiniowa/source/conf.py
+++ b/AlgebraLiniowa/source/conf.py
@@ -140,13 +140,13 @@ html_static_path = ['_static']
 #html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+html_use_index = False
 
 # If true, the index is split into individual pages for each letter.
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True

--- a/AlgebraTrial/source/conf.py
+++ b/AlgebraTrial/source/conf.py
@@ -157,13 +157,13 @@ html_static_path = ['_static']
 #html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+html_use_index = False
 
 # If true, the index is split into individual pages for each letter.
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True

--- a/ElektrycznoscMagnetyzm/source/conf.py
+++ b/ElektrycznoscMagnetyzm/source/conf.py
@@ -149,13 +149,13 @@ html_static_path = ['_static']
 #html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+html_use_index = False
 
 # If true, the index is split into individual pages for each letter.
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True

--- a/Matematyka_Sage/source/conf.py
+++ b/Matematyka_Sage/source/conf.py
@@ -149,13 +149,13 @@ html_static_path = ['_static']
 #html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+html_use_index = False
 
 # If true, the index is split into individual pages for each letter.
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True

--- a/MechanikaStosowana/source/conf.py
+++ b/MechanikaStosowana/source/conf.py
@@ -149,13 +149,13 @@ html_static_path = ['_static']
 #html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+html_use_index = False
 
 # If true, the index is split into individual pages for each letter.
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True

--- a/MetodyMatematycznewBiologii/source/conf.py
+++ b/MetodyMatematycznewBiologii/source/conf.py
@@ -149,13 +149,13 @@ html_static_path = ['_static']
 #html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+html_use_index = False
 
 # If true, the index is split into individual pages for each letter.
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True

--- a/ProcesyNieliniowewBiologii/source/conf.py
+++ b/ProcesyNieliniowewBiologii/source/conf.py
@@ -149,13 +149,13 @@ html_static_path = ['_static']
 #html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+html_use_index = False
 
 # If true, the index is split into individual pages for each letter.
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True

--- a/SagewFizyce/source/conf.py
+++ b/SagewFizyce/source/conf.py
@@ -149,13 +149,13 @@ html_theme_path = ["../.."]
 #html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+html_use_index = False
 
 # If true, the index is split into individual pages for each letter.
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True

--- a/Warsztaty/source/conf.py
+++ b/Warsztaty/source/conf.py
@@ -149,13 +149,13 @@ html_static_path = ['_static']
 #html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+html_use_index = False
 
 # If true, the index is split into individual pages for each letter.
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True

--- a/cloud/static/cloud.css_t
+++ b/cloud/static/cloud.css_t
@@ -37,7 +37,7 @@ div.related
     max-width: 11in;
     background: #5682AD;
     line-height: 1.5em;
-    padding: .5em 0;
+    padding: 0 0;
     color: #ffffff;
 }
 
@@ -59,6 +59,7 @@ div.related a
 {
     color: #ffffff;
     display: inline-block;
+	padding: 0.5em 0;
 }
 
 div.related li {


### PR DESCRIPTION
Wszystkie linki: w menu/next/prev/tytul powinny byc "kafelkami" tak by dało się klikać w cały prostokąt pod tekstem linku.

Usunięte "index" z prawego górnego rogu oraz show source .
