### PR TITLE
reformatting to avoid sagecell inside admonition

### DIFF
--- a/school/source/_templates/layout.html
+++ b/school/source/_templates/layout.html
@@ -7,7 +7,7 @@
 	<script src="http://sagecell.icse.us.edu.pl:6363/static/embedded_sagecell.js"></script>
 
 	<script>sagecell.makeSagecell({inputLocation: ".sage",
-                                       evalButtonText: 'Wykonaj',
+                                       evalButtonText: 'Evaluate',
                                        linked: true});</script>
 
 	<style type="text/css">

--- a/school/source/abitur/de/2015_biathlon.rst
+++ b/school/source/abitur/de/2015_biathlon.rst
@@ -1,88 +1,90 @@
 Bayerisches Abitur in Mathematik 2015
 -------------------------------------
 
-Bei der Wintersportart Biathlon wird bei jeder Schießeinlage auf fünf Scheiben
-geschossen. Ein Biathlet tritt bei einem Einzelrennen zu einer Schießeinlage
-an, bei der er auf jede Scheibe einen Schuss abgibt. Diese Schießeinlage wird
-modellhaft durch eine Bernoullikette mit der Länge 5 und der
-Trefferwahrscheinlichkeit :math:`p` beschrieben.
+.. admonition:: Aufgabe
 
-a) Geben sie für die folgenden Ereignisse A und B jeweils einen Term an, der
-   die Wahrscheinlichkeit eines Ereignisses in Abhängigkeit von :math:`p`
-   beschreibt.  
- | A: „Der Biathlet trifft bei genau vier Schüssen.“   
- | B: „Der Biathlet trifft nur bei den ersten beiden Schüssen.“
+  Bei der Wintersportart Biathlon wird bei jeder Schießeinlage auf fünf Scheiben
+  geschossen. Ein Biathlet tritt bei einem Einzelrennen zu einer Schießeinlage
+  an, bei der er auf jede Scheibe einen Schuss abgibt. Diese Schießeinlage wird
+  modellhaft durch eine Bernoullikette mit der Länge 5 und der
+  Trefferwahrscheinlichkeit :math:`p` beschrieben.
 
-.. admonition:: Lösung
+  a) Geben sie für die folgenden Ereignisse A und B jeweils einen Term an, der
+     die Wahrscheinlichkeit eines Ereignisses in Abhängigkeit von :math:`p`
+     beschreibt.  
+   | A: „Der Biathlet trifft bei genau vier Schüssen.“   
+   | B: „Der Biathlet trifft nur bei den ersten beiden Schüssen.“
 
-  Wir beginnen mit der Wahrscheinlichkeit mit der Aussage B zutrifft. Da die
-  Wahrscheinlichkeit eines Treffers durch :math:`p` gegeben ist, ist die
-  Wahrscheinlichkeit nicht zu treffen gleich :math:`1-p`. Damit ergibt sich die
-  Wahrscheinlichkeit, dass es sich genau bei den ersten beiden Schüssen um
-  Treffer handelt, zu :math:`p^2(1-p)^3`. Wir überprüfen diese Aussage durch eine 
-  Simulation. Dabei dürfen wir allerdings keine perfekte Übereinstimmung erwarten.
-  
-  .. sagecellserver::
-  
-      sage: p = 0.7
-      sage: rounds = 1000000
-      sage: goal = [True, True, False, False, False]
-      sage: successes = 0
-      sage: for round in range(rounds):
-      ...       result = [random() < p for _ in range(5)]
-      ...       if result == goal:
-      ...           successes = successes+1
-      sage: print N(successes/rounds), p^2*(1-p)^3
-  
-  .. end of output
-  
-  Wenden wir uns nun der Aussage A zu. Die Wahrscheinlichkeit für eine ganz
-  bestimmte Sequenz von Treffern und Fehlschüssen ist in Analogie zur vorigen
-  Überlegung bei nun vier Treffern gleich :math:`p^4(1-p)`. Allerdings ist nicht
-  festgelegt, der wievielte Schuss ein Fehlschuss sein soll. Die Zahl der
-  Möglichkeiten, :math:`M` Ereignisse auf :math:`N` Positionen zu verteilen,
-  ist durch den Binomialkoeffizenten
-  
-  .. math::
-  
-     \binom{N}{M} = \frac{N!}{M!(N-M)!}
-  
-  gegeben. In unserem Fall ergibt sich somit für die gesuchte Wahrscheinlichkeit
-  
-  .. math::
-  
-     \binom{5}{4}p^4(1-p) = 5p^4(1-p).
-  
-  Nachdem wir kurz den hier verwendeten Binomialkoeffizienten verifiziert haben
-  
-  .. sagecellserver::
-  
-      sage: binomial(5, 4)
-  
-  .. end of output
-  
-  überprüfen wir unser Ergebnis für die Wahrscheinlichkeit wieder mit Hilfe einer 
-  Simulation:
-  
-  .. sagecellserver::
-  
-      sage: p = 0.7
-      sage: rounds = 1000000
-      sage: successes = 0
-      sage: for round in range(rounds):
-      ...       result = [random() < p for _ in range(5)]
-      ...       if sum(result) == 4:
-      ...           successes = successes+1
-      sage: print N(successes/rounds), 5*p^4*(1-p)
-  
-  .. end of output
+  b) Erläutern Sie anhand eines Beispiels, dass die modellhafte Beschreibung der
+     Schießeinlage durch eine Bernoullikette unter Umständen der Realität nicht
+     gerecht wird.
 
-b) Erläutern Sie anhand eines Beispiels, dass die modellhafte Beschreibung der
-   Schießeinlage durch eine Bernoullikette unter Umständen der Realität nicht
-   gerecht wird.
+**Lösung zu Teil a**     
 
-.. admonition:: Lösung
+Wir beginnen mit der Wahrscheinlichkeit mit der Aussage B zutrifft. Da die
+Wahrscheinlichkeit eines Treffers durch :math:`p` gegeben ist, ist die
+Wahrscheinlichkeit nicht zu treffen gleich :math:`1-p`. Damit ergibt sich die
+Wahrscheinlichkeit, dass es sich genau bei den ersten beiden Schüssen um
+Treffer handelt, zu :math:`p^2(1-p)^3`. Wir überprüfen diese Aussage durch eine 
+Simulation. Dabei dürfen wir allerdings keine perfekte Übereinstimmung erwarten.
 
-  Die Bernoullikette nimmt an, dass die Trefferwahrscheinlichkeit für jeden
-  Schuss gleich ist. In Wirklichkeit kann es aber zum Beispiel sein, dass die
-  Trefferwahrscheinlichkeit nach einem Fehlschuss abnimmt.
+.. sagecellserver::
+
+    sage: p = 0.7
+    sage: rounds = 1000000
+    sage: goal = [True, True, False, False, False]
+    sage: successes = 0
+    sage: for round in range(rounds):
+    ...       result = [random() < p for _ in range(5)]
+    ...       if result == goal:
+    ...           successes = successes+1
+    sage: print N(successes/rounds), p^2*(1-p)^3
+
+.. end of output
+
+Wenden wir uns nun der Aussage A zu. Die Wahrscheinlichkeit für eine ganz
+bestimmte Sequenz von Treffern und Fehlschüssen ist in Analogie zur vorigen
+Überlegung bei nun vier Treffern gleich :math:`p^4(1-p)`. Allerdings ist nicht
+festgelegt, der wievielte Schuss ein Fehlschuss sein soll. Die Zahl der
+Möglichkeiten, :math:`M` Ereignisse auf :math:`N` Positionen zu verteilen,
+ist durch den Binomialkoeffizenten
+
+.. math::
+
+   \binom{N}{M} = \frac{N!}{M!(N-M)!}
+
+gegeben. In unserem Fall ergibt sich somit für die gesuchte Wahrscheinlichkeit
+
+.. math::
+
+   \binom{5}{4}p^4(1-p) = 5p^4(1-p).
+
+Nachdem wir kurz den hier verwendeten Binomialkoeffizienten verifiziert haben
+
+.. sagecellserver::
+
+    sage: binomial(5, 4)
+
+.. end of output
+
+überprüfen wir unser Ergebnis für die Wahrscheinlichkeit wieder mit Hilfe einer 
+Simulation:
+
+.. sagecellserver::
+
+    sage: p = 0.7
+    sage: rounds = 1000000
+    sage: successes = 0
+    sage: for round in range(rounds):
+    ...       result = [random() < p for _ in range(5)]
+    ...       if sum(result) == 4:
+    ...           successes = successes+1
+    sage: print N(successes/rounds), 5*p^4*(1-p)
+
+.. end of output
+
+**Lösung zu Teil b**
+
+Die Bernoullikette nimmt an, dass die Trefferwahrscheinlichkeit für jeden
+Schuss gleich ist. In Wirklichkeit kann es aber zum Beispiel sein, dass die
+Trefferwahrscheinlichkeit nach einem Fehlschuss abnimmt.

--- a/school/source/abitur/de/2015_funktionen.rst
+++ b/school/source/abitur/de/2015_funktionen.rst
@@ -1,68 +1,71 @@
 Bayerisches Abitur in Mathematik 2015
 -------------------------------------
 
-Gegeben sind die in :math:`\mathbb{R}` definierten Funktionen :math:`f, g` und
-:math:`h` mit :math:`f(x)=x^2-x+1`, :math:`g(x)=x^3-x+1` und
-:math:`h(x)=x^4+x^2+1`.
+.. admonition:: Aufgabe
 
-a) Die Abbildung zeigt den Graphen einer der drei Funktionen. Geben Sie an, um
-   welche Funktion es sich handelt. Begründen Sie, dass der Graph die anderen
-   beiden Funktionen nicht darstellt.
+  Gegeben sind die in :math:`\mathbb{R}` definierten Funktionen :math:`f, g` und
+  :math:`h` mit :math:`f(x)=x^2-x+1`, :math:`g(x)=x^3-x+1` und
+  :math:`h(x)=x^4+x^2+1`.
 
-.. image:: ../figs/abiturpruefung_mathematik_cas_2015_pruefungsteil_a_1_2_a.png
-   :align: center
+  a) Die Abbildung zeigt den Graphen einer der drei Funktionen. Geben Sie an, um
+     welche Funktion es sich handelt. Begründen Sie, dass der Graph die anderen
+     beiden Funktionen nicht darstellt.
 
-.. admonition:: Lösung
+  .. image:: ../figs/abiturpruefung_mathematik_cas_2015_pruefungsteil_a_1_2_a.png
+     :align: center
 
-  Die vorgegebene Funktion hat zwei Extrema. Damit kommt die Funktion
-  :math:`f(x)` nicht in Frage, da die Ableitung einer quadratischen Funktion nur
-  eine Nullstelle besitzt. Zudem kann die vorgegebene Funktion negative Werte
-  annehmen. Dies schließt die Funktion :math:`h(x)` aus. Bei der dargestellten
-  Funktion handelt es sich also offenbar um die Funktion :math:`g(x)`. Wir
-  überprüfen die Vermutung mit Sage:
-  
-  .. sagecellserver::
-  
-      sage: ranges = {'xmin': -2, 'xmax': 2.5, 'ymin': -2.5, 'ymax': 2.5}
-      sage: p = sum([plot(x^2-x+1, color='blue', **ranges),
-      ...            plot(x^3-x+1, color='red', **ranges),
-      ...            plot(x^4+x^2+1, color='green', **ranges)])
-      sage: p.show(figsize=(2.7, 3))
-  
-  .. end of output
-  
-  In der Tat passt der rot dargestellte Funktionsgraph der Funktion :math:`g(x)`
-  zu der Vorgabe.
+  b) Die erste Ableitungsfunktion von :math:`h` ist :math:`h'`. Bestimmen Sie
+     den Wert von :math:`\int_0^1h'(x)\mathrm{d}x`.
 
-b) Die erste Ableitungsfunktion von :math:`h` ist :math:`h'`. Bestimmen Sie den    Wert von :math:`\int_0^1h'(x)\mathrm{d}x`.
+**Lösung zu Teil a**
 
-.. admonition:: Lösung
+Die vorgegebene Funktion hat zwei Extrema. Damit kommt die Funktion
+:math:`f(x)` nicht in Frage, da die Ableitung einer quadratischen Funktion nur
+eine Nullstelle besitzt. Zudem kann die vorgegebene Funktion negative Werte
+annehmen. Dies schließt die Funktion :math:`h(x)` aus. Bei der dargestellten
+Funktion handelt es sich also offenbar um die Funktion :math:`g(x)`. Wir
+überprüfen die Vermutung mit Sage:
 
-  Die Stammfunktion der Ableitung einer Funktion ist die Funktion selbst. Daher
-  folgt
-  
-  .. math::
-  
-     \int_0^1h'(x)\mathrm{d}x = h(1)-h(0) = 3-1 = 2.
-  
-  In Sage differenzieren wir zur Überprüfung zunächst die Funktion
-  :math:`h(x)` und bestimmen dann das gesuchte bestimmte Integral:
-  
-  .. sagecellserver::
-  
-      sage: h(x) = x^4+x^2+1
-      sage: dh(x) = diff(h, x)
-      sage: print 'Ableitung von h(x):', dh
-      sage: print 'Wert des bestimmten Integrals:', integrate(dh(x), x, 0, 1)
-  
-  .. end of output
-  
-  Dieses Ergebnis erhalten wir natürlich auch, wenn wir entsprechend der obigen
-  Überlegung die Funktionswerte an den Integrationsgrenzen voneinander abziehen:
-  
-  .. sagecellserver::
-  
-      sage: h(x) = x^4+x^2+1
-      sage: h(1)-h(0)
-  
-  .. end of output
+.. sagecellserver::
+
+    sage: ranges = {'xmin': -2, 'xmax': 2.5, 'ymin': -2.5, 'ymax': 2.5}
+    sage: p = sum([plot(x^2-x+1, color='blue', **ranges),
+    ...            plot(x^3-x+1, color='red', **ranges),
+    ...            plot(x^4+x^2+1, color='green', **ranges)])
+    sage: p.show(figsize=(2.7, 3))
+
+.. end of output
+
+In der Tat passt der rot dargestellte Funktionsgraph der Funktion :math:`g(x)`
+zu der Vorgabe.
+
+**Lösung zu Teil b**
+
+Die Stammfunktion der Ableitung einer Funktion ist die Funktion selbst. Daher
+folgt
+
+.. math::
+
+   \int_0^1h'(x)\mathrm{d}x = h(1)-h(0) = 3-1 = 2.
+
+In Sage differenzieren wir zur Überprüfung zunächst die Funktion
+:math:`h(x)` und bestimmen dann das gesuchte bestimmte Integral:
+
+.. sagecellserver::
+
+    sage: h(x) = x^4+x^2+1
+    sage: dh(x) = diff(h, x)
+    sage: print 'Ableitung von h(x):', dh
+    sage: print 'Wert des bestimmten Integrals:', integrate(dh(x), x, 0, 1)
+
+.. end of output
+
+Dieses Ergebnis erhalten wir natürlich auch, wenn wir entsprechend der obigen
+Überlegung die Funktionswerte an den Integrationsgrenzen voneinander abziehen:
+
+.. sagecellserver::
+
+    sage: h(x) = x^4+x^2+1
+    sage: h(1)-h(0)
+
+.. end of output

--- a/school/source/abitur/de/2015_funktionenschar.rst
+++ b/school/source/abitur/de/2015_funktionenschar.rst
@@ -1,37 +1,39 @@
 Bayerisches Abitur in Mathematik 2015
 -------------------------------------
 
-Gegeben ist die Schar der in :math:`\mathbb{R}` definierten Funktionen
-:math:`f_a : x\mapsto x\mathrm{e}^{ax}` mit
-:math:`a\in\mathbb{R}\backslash\{0\}`. Ermitteln Sie, für welchen Wert von
-:math:`a` die erste Ableitung von :math:`f_a` an der Stelle :math:`x=2` den
-Wert 0 besitzt.
+.. admonition:: Aufgabe
 
-.. admonition:: Lösung
+  Gegeben ist die Schar der in :math:`\mathbb{R}` definierten Funktionen
+  :math:`f_a : x\mapsto x\mathrm{e}^{ax}` mit
+  :math:`a\in\mathbb{R}\backslash\{0\}`. Ermitteln Sie, für welchen Wert von
+  :math:`a` die erste Ableitung von :math:`f_a` an der Stelle :math:`x=2` den
+  Wert 0 besitzt.
 
-  Für die Ableitung der gegebenen Funktion erhält man
-  
-  .. math::
-  
-     \frac{\mathrm{d}f_a}{\mathrm{d}x} = (1+ax)\mathrm{e}^{ax}
-  
-  und damit
-  
-  .. math::
-  
-     \left.\frac{\mathrm{d}f_a}{\mathrm{d}x}\right\vert_{x=2} =
-      (1+2a)\mathrm{e}^{2a}.
-  
-  Die Ableitung verschwindet somit, wenn :math:`1+2a=0`, also für :math:`a=-1/2`.
-  
-  Diese Rechnung lässt sich mit Sage überprüfen:
-  
-  .. sagecellserver::
-  
-      sage: a = var('a')
-      sage: f(x, a) = x*exp(a*x)
-      sage: df = f.derivative(x)
-      sage: print 'Ableitung von f:', df
-      sage: solve(df(2, a) == 0, a)
-  
-  .. end of output
+**Lösung**
+
+Für die Ableitung der gegebenen Funktion erhält man
+
+.. math::
+
+   \frac{\mathrm{d}f_a}{\mathrm{d}x} = (1+ax)\mathrm{e}^{ax}
+
+und damit
+
+.. math::
+
+   \left.\frac{\mathrm{d}f_a}{\mathrm{d}x}\right\vert_{x=2} =
+    (1+2a)\mathrm{e}^{2a}.
+
+Die Ableitung verschwindet somit, wenn :math:`1+2a=0`, also für :math:`a=-1/2`.
+
+Diese Rechnung lässt sich mit Sage überprüfen:
+
+.. sagecellserver::
+
+    sage: a = var('a')
+    sage: f(x, a) = x*exp(a*x)
+    sage: df = f.derivative(x)
+    sage: print 'Ableitung von f:', df
+    sage: solve(df(2, a) == 0, a)
+
+.. end of output

--- a/school/source/abitur/de/2015_funktionseigenschaften.rst
+++ b/school/source/abitur/de/2015_funktionseigenschaften.rst
@@ -1,65 +1,67 @@
 Bayerisches Abitur in Mathematik 2015
 -------------------------------------
 
-Geben Sie jeweils den Term einer Funktion an, die die angegebene(n)
-Eigenschaft(en) besitzt.
+.. admonition:: Aufgabe
 
-a) Die Funktion :math:`g` hat die maximale Definitionsmenge :math:`]-\infty; 5]`.
+  Geben Sie jeweils den Term einer Funktion an, die die angegebene(n)
+  Eigenschaft(en) besitzt.
 
-.. admonition:: Lösung
+  a) Die Funktion :math:`g` hat die maximale Definitionsmenge :math:`]-\infty; 5]`.
 
-  Eine Funktion mit Definitionsmenge :math:`[0; \infty[` ist
-  :math:`x\mapsto\sqrt{x}`. Daraus erhalten wir mit :math:`g(x)=\sqrt{5-x}`
-  eine mögliche Funktion mit der gewünschten Definitionsmenge.
+  b) Die Funktion :math:`k` hat in :math:`x=2` eine Nullstelle und in
+     :math:`x=-3` eine Polstelle ohne Vorzeichenwechsel. Der Graph von :math:`k`
+     hat die Gerade mit der Gleichung :math:`y=1` als Asymptote.
 
-b) Die Funktion :math:`k` hat in :math:`x=2` eine Nullstelle und in
-   :math:`x=-3` eine Polstelle ohne Vorzeichenwechsel. Der Graph von :math:`k`
-   hat die Gerade mit der Gleichung :math:`y=1` als Asymptote.
+**Lösung zu Teil a**
 
-.. admonition:: Lösung
+Eine Funktion mit Definitionsmenge :math:`[0; \infty[` ist
+:math:`x\mapsto\sqrt{x}`. Daraus erhalten wir mit :math:`g(x)=\sqrt{5-x}`
+eine mögliche Funktion mit der gewünschten Definitionsmenge.
 
-  Die Funktion :math:`k(x)` lässt sich als gebrochen-rationale Funktion wählen.
-  Wegen der Nullstelle bei :math:`x=2` muss der Zähler mindestens einen Faktor
-  :math:`x-2` enthalten. Eine Polstelle bei :math:`x=-3` ohne Vorzeichenwechsel
-  erhält man mit einem Faktor :math:`(x+3)^2` im Nenner. Um das gesuchte
-  asymptotische Verhalten für :math:`\vert x\vert\to\infty` zu erhalten, muss
-  dann auch der Faktor im Zähler quadriert werden. Damit erhalten wir die
-  Funktion
-  
-  .. math::
-  
-     k(x)=\frac{(x-2)^2}{(x+3)^2}.
-  
-  Mit Hilfe von Sage zeigen wir nun, dass diese Funktion in der Tat das
-  gewünschte Verhalten aufweist.
-  
-  Nullstelle bei :math:`x=2`:
-  
-  .. sagecellserver::
-  
-      sage: k(x) = ((x-2)/(x+3))^2
-      sage: plot(k, xmin=0, xmax=4, ymin=-0.1, ymax=0.5, figsize=(4, 2.5))
-  
-  .. end of output
-  
-  Polstelle bei :math:`x=-3` ohne Vorzeichenwechsel:
-  
-  .. sagecellserver::
-  
-      sage: k(x) = ((x-2)/(x+3))^2
-      sage: plot(k, xmin=-6, xmax=0, ymin=0, ymax=1000, figsize=(4, 2.5))
-  
-  .. end of output
-  
-  Annäherung an die Gerade :math:`y=1` für :math:`\vert x\vert\to 1`:
-  
-  .. sagecellserver::
-  
-      sage: k(x) = ((x-2)/(x+3))^2
-      sage: xmax = 1000
-      sage: xmin = -xmax
-      sage: p = plot(k, xmin=xmin, xmax=xmax, ymin=0.5, ymax=1.5)
-      sage: p = p+line([(xmin, 1), (xmax, 1)], linestyle='dashed')
-      sage: p.show(figsize=(4, 2.5))
-  
-  .. end of output
+**Lösung zu Teil b**
+
+Die Funktion :math:`k(x)` lässt sich als gebrochen-rationale Funktion wählen.
+Wegen der Nullstelle bei :math:`x=2` muss der Zähler mindestens einen Faktor
+:math:`x-2` enthalten. Eine Polstelle bei :math:`x=-3` ohne Vorzeichenwechsel
+erhält man mit einem Faktor :math:`(x+3)^2` im Nenner. Um das gesuchte
+asymptotische Verhalten für :math:`\vert x\vert\to\infty` zu erhalten, muss
+dann auch der Faktor im Zähler quadriert werden. Damit erhalten wir die
+Funktion
+
+.. math::
+
+   k(x)=\frac{(x-2)^2}{(x+3)^2}.
+
+Mit Hilfe von Sage zeigen wir nun, dass diese Funktion in der Tat das
+gewünschte Verhalten aufweist.
+
+Nullstelle bei :math:`x=2`:
+
+.. sagecellserver::
+
+    sage: k(x) = ((x-2)/(x+3))^2
+    sage: plot(k, xmin=0, xmax=4, ymin=-0.1, ymax=0.5, figsize=(4, 2.5))
+
+.. end of output
+
+Polstelle bei :math:`x=-3` ohne Vorzeichenwechsel:
+
+.. sagecellserver::
+
+    sage: k(x) = ((x-2)/(x+3))^2
+    sage: plot(k, xmin=-6, xmax=0, ymin=0, ymax=1000, figsize=(4, 2.5))
+
+.. end of output
+
+Annäherung an die Gerade :math:`y=1` für :math:`\vert x\vert\to 1`:
+
+.. sagecellserver::
+
+    sage: k(x) = ((x-2)/(x+3))^2
+    sage: xmax = 1000
+    sage: xmin = -xmax
+    sage: p = plot(k, xmin=xmin, xmax=xmax, ymin=0.5, ymax=1.5)
+    sage: p = p+line([(xmin, 1), (xmax, 1)], linestyle='dashed')
+    sage: p.show(figsize=(4, 2.5))
+
+.. end of output

--- a/school/source/abitur/de/2015_nullstellen_log.rst
+++ b/school/source/abitur/de/2015_nullstellen_log.rst
@@ -1,32 +1,34 @@
 Bayerisches Abitur in Mathematik 2015
 -------------------------------------
 
-Bestimmen Sie für :math:`x\in\mathbb{R}` die Lösungen der Gleichung
-:math:`(4x-3)\cdot\ln\left(x^2-5x+7\right)=0`.
+.. admonition:: Aufgabe
 
-.. admonition:: Lösung
+  Bestimmen Sie für :math:`x\in\mathbb{R}` die Lösungen der Gleichung
+  :math:`(4x-3)\cdot\ln\left(x^2-5x+7\right)=0`.
 
-  Die Nullstellen der Funktion auf der linken Seite erhält man durch Bestimmung
-  der Nullstellen der beiden Faktoren.
+**Lösung**
 
-  Aus der Forderung :math:`4x-3=0` folgt durch Auflösen nach :math:`x`
-  unmittelbar die Nullstelle :math:`x_1 = 3/4`.
+Die Nullstellen der Funktion auf der linken Seite erhält man durch Bestimmung
+der Nullstellen der beiden Faktoren.
 
-  Der zweite Faktor verschwindet, wenn das Argument des Logarithmus gleich Eins
-  ist. Daraus ergibt sich die Forderung :math:`x^2-5x+7=1`. Die Lösung der daraus 
-  resultierenden quadratischen Gleichung :math:`x^2-5x+6=0` ergibt sich zu
+Aus der Forderung :math:`4x-3=0` folgt durch Auflösen nach :math:`x`
+unmittelbar die Nullstelle :math:`x_1 = 3/4`.
 
-  .. math::
+Der zweite Faktor verschwindet, wenn das Argument des Logarithmus gleich Eins
+ist. Daraus ergibt sich die Forderung :math:`x^2-5x+7=1`. Die Lösung der daraus 
+resultierenden quadratischen Gleichung :math:`x^2-5x+6=0` ergibt sich zu
 
-     x_{2,3} = \frac{5\pm\sqrt{25-24}}{2}.
+.. math::
 
-  Damit erhalten wir zwei weitere Nullstellen :math:`x_2=2` und :math:`x_3=3`.
+   x_{2,3} = \frac{5\pm\sqrt{25-24}}{2}.
 
-  Dieses Ergebnis lässt sich leicht mit Sage überprüfen:
+Damit erhalten wir zwei weitere Nullstellen :math:`x_2=2` und :math:`x_3=3`.
 
-  .. sagecellserver::
+Dieses Ergebnis lässt sich leicht mit Sage überprüfen:
 
-    sage: x = var('x')
-    sage: solve((4*x-3)*ln(x^2-5*x+7) == 0, x)
+.. sagecellserver::
 
-  .. end of output
+  sage: x = var('x')
+  sage: solve((4*x-3)*ln(x^2-5*x+7) == 0, x)
+
+.. end of output

--- a/school/source/abitur/de/2015_parallelogramm.rst
+++ b/school/source/abitur/de/2015_parallelogramm.rst
@@ -1,97 +1,99 @@
 Bayerisches Abitur in Mathematik 2015
 -------------------------------------
 
-Die Gerade g verläuft durch die Punkte A(0|1|2) und B(2|5|6).
+.. admonition:: Aufgabe
 
-a) Zeigen Sie, dass die Punkte A und B den Abstand 6 haben. Die Punkte C und D
-   liegen auf g und haben von A jeweils den Abstand 12. Bestimmen Sie die
-   Koordinaten von C und D.
+  Die Gerade :math:`g` verläuft durch die Punkte A(0|1|2) und B(2|5|6).
 
-.. admonition:: Lösung
+  a) Zeigen Sie, dass die Punkte A und B den Abstand 6 haben. Die Punkte C und D
+     liegen auf :math:`g` und haben von A jeweils den Abstand 12. Bestimmen Sie
+     die Koordinaten von C und D.
 
-  Der Verbindungsvektor von Punkt A nach Punkt B lautet (2, 4, 4) und hat damit
-  die Länge :math:`\sqrt{2^2+4^2+4^2}=\sqrt{36}=6`. Die Punkte C und D ergeben
-  sich, indem man das Doppelte des Verbindungsvektors zwischen A und B zum
-  Ortsvektor von A addiert bzw. subtrahiert. Wir erhalten so die Punkte C(4|9|10) 
-  und D(-4|-7|-6).
-  
-  Wir führen nun die entsprechenden Überlegungen mit der Hilfe von Sage durch.
-  Zunächst berechnen wir den Abstand der Punkte A und B und bestimmen dann die
-  Koordinaten der Punkte C und D. Abschließend überprüfen wir noch, ob der
-  Abstand zwischen den Punkten C und D und dem Punkt A wie gewünscht gleich 12
-  ist.
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 1, 2])
-      sage: b = vector([2, 5, 6])
-      sage: print 'Länge des Verbindungsvektors von A nach B:', norm(b-a)
-      sage: c = a+2*(b-a)
-      sage: d = a-2*(b-a)
-      sage: print 'Koordinaten von C:', c
-      sage: print 'Koordinaten von D:', d
-      sage: print 'Abstand der Punkte A und C:', norm(c-a)
-      sage: print 'Abstand der Punkte A und D:', norm(d-a)
-  
-  .. end of output
+  b) Die Punkte A, B und E(1|2|5) sollen mit einem weiteren Punkt die Eckpunkte
+     eines Parallelogramms bilden. Für die Lage des vierten Eckpunkts gibt es
+     mehrere Möglichkeiten. Geben Sie für zwei dieser Möglichkeiten die
+     Koordinaten des vierten Eckpunkts an.
 
-b) Die Punkte A, B und E(1|2|5) sollen mit einem weiteren Punkt die Eckpunkte
-   eines Parallelogramms bilden. Für die Lage des vierten Eckpunkts gibt es
-   mehrere Möglichkeiten. Geben Sie für zwei dieser Möglichkeiten die
-   Koordinaten des vierten Eckpunkts an.
+**Lösung zu Teil a**
 
-.. admonition:: Lösung
+Der Verbindungsvektor von Punkt A nach Punkt B lautet (2, 4, 4) und hat damit
+die Länge :math:`\sqrt{2^2+4^2+4^2}=\sqrt{36}=6`. Die Punkte C und D ergeben
+sich, indem man das Doppelte des Verbindungsvektors zwischen A und B zum
+Ortsvektor von A addiert bzw. subtrahiert. Wir erhalten so die Punkte C(4|9|10) 
+und D(-4|-7|-6).
 
-  Man wählt zwei der drei möglichen Verbindungsvektoren und fügt an einen
-  Verbindungsvektor den anderen Verbindungsvektor an, um den vierten Punkt zu
-  erhalten.
-  
-  Im ersten Fall verwenden wir die Verbindungvektoren von A nach B und von A nach 
-  E:
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 1, 2])
-      sage: b = vector([2, 5, 6])
-      sage: e = vector([1, 2, 5])
-      sage: a_to_b = b-a
-      sage: a_to_e = e-a
-      sage: f1 = b+a_to_e
-      sage: f2 = e+a_to_b
-      sage: f1, f2
-  
-  .. end of output
-  
-  Die beiden Berechnungswege ergeben, wie es auch sein muss, das gleiche
-  Resultat. Der vierte Eckpunkt ist also zum Beispiel F(3|6|9).
-  
-  Ein anderes Parallelogramm ergibt sich, wenn der Punkt B diagonal gegenüber
-  dem neuen Punkt liegt.
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 1, 2])
-      sage: b = vector([2, 5, 6])
-      sage: e = vector([1, 2, 5])
-      sage: b_to_a = a-b
-      sage: b_to_e = e-b
-      sage: f1 = a+b_to_e
-      sage: f2 = e+b_to_a
-      sage: f1, f2
-  
-  .. end of output
-  
-  Der Vollständigkeit halber berechnen wir noch den dritten möglichen Eckpunkt.
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 1, 2])
-      sage: b = vector([2, 5, 6])
-      sage: e = vector([1, 2, 5])
-      sage: e_to_a = a-e
-      sage: e_to_b = b-e
-      sage: f1 = a+e_to_b
-      sage: f2 = b+e_to_a
-      sage: f1, f2
+Wir führen nun die entsprechenden Überlegungen mit der Hilfe von Sage durch.
+Zunächst berechnen wir den Abstand der Punkte A und B und bestimmen dann die
+Koordinaten der Punkte C und D. Abschließend überprüfen wir noch, ob der
+Abstand zwischen den Punkten C und D und dem Punkt A wie gewünscht gleich 12
+ist.
 
-  .. end of output
+.. sagecellserver::
+
+    sage: a = vector([0, 1, 2])
+    sage: b = vector([2, 5, 6])
+    sage: print 'Länge des Verbindungsvektors von A nach B:', norm(b-a)
+    sage: c = a+2*(b-a)
+    sage: d = a-2*(b-a)
+    sage: print 'Koordinaten von C:', c
+    sage: print 'Koordinaten von D:', d
+    sage: print 'Abstand der Punkte A und C:', norm(c-a)
+    sage: print 'Abstand der Punkte A und D:', norm(d-a)
+
+.. end of output
+
+**Lösung zu Teil b**
+
+Man wählt zwei der drei möglichen Verbindungsvektoren und fügt an einen
+Verbindungsvektor den anderen Verbindungsvektor an, um den vierten Punkt zu
+erhalten.
+
+Im ersten Fall verwenden wir die Verbindungvektoren von A nach B und von A nach 
+E:
+
+.. sagecellserver::
+
+    sage: a = vector([0, 1, 2])
+    sage: b = vector([2, 5, 6])
+    sage: e = vector([1, 2, 5])
+    sage: a_to_b = b-a
+    sage: a_to_e = e-a
+    sage: f1 = b+a_to_e
+    sage: f2 = e+a_to_b
+    sage: f1, f2
+
+.. end of output
+
+Die beiden Berechnungswege ergeben, wie es auch sein muss, das gleiche
+Resultat. Der vierte Eckpunkt ist also zum Beispiel F(3|6|9).
+
+Ein anderes Parallelogramm ergibt sich, wenn der Punkt B diagonal gegenüber
+dem neuen Punkt liegt.
+
+.. sagecellserver::
+
+    sage: a = vector([0, 1, 2])
+    sage: b = vector([2, 5, 6])
+    sage: e = vector([1, 2, 5])
+    sage: b_to_a = a-b
+    sage: b_to_e = e-b
+    sage: f1 = a+b_to_e
+    sage: f2 = e+b_to_a
+    sage: f1, f2
+
+.. end of output
+
+Der Vollständigkeit halber berechnen wir noch den dritten möglichen Eckpunkt.
+
+.. sagecellserver::
+
+    sage: a = vector([0, 1, 2])
+    sage: b = vector([2, 5, 6])
+    sage: e = vector([1, 2, 5])
+    sage: e_to_a = a-e
+    sage: e_to_b = b-e
+    sage: f1 = a+e_to_b
+    sage: f2 = b+e_to_a
+    sage: f1, f2
+
+.. end of output

--- a/school/source/abitur/de/2015_pyramide.rst
+++ b/school/source/abitur/de/2015_pyramide.rst
@@ -1,84 +1,86 @@
 Bayerisches Abitur in Mathematik 2015
 -------------------------------------
 
-Betrachtet wird die Pyramide ABCDS mit A(0|0|0), B(4|4|2), C(8|0|2), D(4|-4|0)
-und S(1|1|-4). Die Grundfläche ist ein Parallelogramm.
+.. admonition:: Aufgabe
 
-a) Weisen Sie nach, dass das Parallelogramm ABCD ein Rechteck ist.
+  Betrachtet wird die Pyramide ABCDS mit A(0|0|0), B(4|4|2), C(8|0|2), D(4|-4|0)
+  und S(1|1|-4). Die Grundfläche ist ein Parallelogramm.
 
-.. admonition:: Lösung
+  a) Weisen Sie nach, dass das Parallelogramm ABCD ein Rechteck ist.
 
-  Ein Rechteck liegt vor, wenn ausgehend von einem Eckpunkt der Winkel zwischen
-  den beiden kürzesten Verbindungsvektoren zu den anderen Eckpunkten gleich
-  90 Grad ist.
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 0, 0])
-      sage: b = vector([4, 4, 2])
-      sage: c = vector([8, 0, 2])
-      sage: d = vector([4, -4, 0])
-      sage: print ' Abstand A-B:', N(norm(b-a))
-      sage: print ' Abstand A-C:', N(norm(c-a))
-      sage: print ' Abstand A-D:', N(norm(d-a))
-      sage: (b-a).dot_product(d-a)
-  
-  .. end of output
-  
-  Die Verbindungsvektoren von A nach B und D stehen demnach senkrecht
-  aufeinander. Der Punkt C liegt diagonal gegenüber A. Es liegt somit ein
-  Rechteck vor. Da diese Lösung von der Vorgabe abhängt, dass ABCD ein
-  Parallelogramm ist, überprüfen wir noch die anderen drei Innenwinkel.
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 0, 0])
-      sage: b = vector([4, 4, 2])
-      sage: c = vector([8, 0, 2])
-      sage: d = vector([4, -4, 0])
-      sage: (c-b).dot_product(a-b), (d-c).dot_product(b-c), (a-d).dot_product(c-d)
-  
-  .. end of output
+  b) Die Kante [AS] steht senkrecht auf der Grundfläche ABCD. Der Flächeninhalt
+     der Grundfläche beträgt :math:`24\sqrt{2}`. Ermitteln Sie das Volumen der
+     Pyramide.
 
-b) Die Kante [AS] steht senkrecht auf der Grundfläche ABCD. Der Flächeninhalt
-   der Grundfläche beträgt :math:`24\sqrt{2}`. Ermitteln Sie das Volumen der
-   Pyramide.
+**Lösung zu Teil a**
 
-.. admonition:: Lösung
+Ein Rechteck liegt vor, wenn ausgehend von einem Eckpunkt der Winkel zwischen
+den beiden kürzesten Verbindungsvektoren zu den anderen Eckpunkten gleich
+90 Grad ist.
 
-  Nachdem der Verbindungsvektor von A nach S senkrecht auf der Grundfläche steht, 
-  gibt seine Länge die Höhe :math:`h` der Pyramide an. Die Grundfläche ist als
-  :math:`A=24\sqrt{2}` vorgegeben, was wir kurz überprüfen wollen:
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 0, 0])
-      sage: b = vector([4, 4, 2])
-      sage: d = vector([4, -4, 0])
-      sage: norm(a-b)*norm(a-d)
-  
-  .. end of output
-  
-  Die Höhe der Pyramide ist
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 0, 0])
-      sage: s = vector([1, 1, -4])
-      sage: norm(s-a)
-  
-  .. end of output
-  
-  Somit ergibt sich das Volumen zu :math:`V=\frac{h}{3}A=48`. Dieses Ergebnis
-  lässt sich auch direkt mit Hilfe von Sage bestätigen.
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 0, 0])
-      sage: b = vector([4, 4, 2])
-      sage: c = vector([8, 0, 2])
-      sage: d = vector([4, -4, 0])
-      sage: s = vector([1, 1, -4])
-      sage: Polyhedron(vertices=[a, b, c, d, s]).volume()
-  
-  .. end of output
+.. sagecellserver::
+
+    sage: a = vector([0, 0, 0])
+    sage: b = vector([4, 4, 2])
+    sage: c = vector([8, 0, 2])
+    sage: d = vector([4, -4, 0])
+    sage: print ' Abstand A-B:', N(norm(b-a))
+    sage: print ' Abstand A-C:', N(norm(c-a))
+    sage: print ' Abstand A-D:', N(norm(d-a))
+    sage: (b-a).dot_product(d-a)
+
+.. end of output
+
+Die Verbindungsvektoren von A nach B und D stehen demnach senkrecht
+aufeinander. Der Punkt C liegt diagonal gegenüber A. Es liegt somit ein
+Rechteck vor. Da diese Lösung von der Vorgabe abhängt, dass ABCD ein
+Parallelogramm ist, überprüfen wir noch die anderen drei Innenwinkel.
+
+.. sagecellserver::
+
+    sage: a = vector([0, 0, 0])
+    sage: b = vector([4, 4, 2])
+    sage: c = vector([8, 0, 2])
+    sage: d = vector([4, -4, 0])
+    sage: (c-b).dot_product(a-b), (d-c).dot_product(b-c), (a-d).dot_product(c-d)
+
+.. end of output
+
+**Lösung zu Teil b**
+
+Nachdem der Verbindungsvektor von A nach S senkrecht auf der Grundfläche steht, 
+gibt seine Länge die Höhe :math:`h` der Pyramide an. Die Grundfläche ist als
+:math:`A=24\sqrt{2}` vorgegeben, was wir kurz überprüfen wollen:
+
+.. sagecellserver::
+
+    sage: a = vector([0, 0, 0])
+    sage: b = vector([4, 4, 2])
+    sage: d = vector([4, -4, 0])
+    sage: norm(a-b)*norm(a-d)
+
+.. end of output
+
+Die Höhe der Pyramide ist
+
+.. sagecellserver::
+
+    sage: a = vector([0, 0, 0])
+    sage: s = vector([1, 1, -4])
+    sage: norm(s-a)
+
+.. end of output
+
+Somit ergibt sich das Volumen zu :math:`V=\frac{h}{3}A=48`. Dieses Ergebnis
+lässt sich auch direkt mit Hilfe von Sage bestätigen.
+
+.. sagecellserver::
+
+    sage: a = vector([0, 0, 0])
+    sage: b = vector([4, 4, 2])
+    sage: c = vector([8, 0, 2])
+    sage: d = vector([4, -4, 0])
+    sage: s = vector([1, 1, -4])
+    sage: Polyhedron(vertices=[a, b, c, d, s]).volume()
+
+.. end of output

--- a/school/source/abitur/de/2015_sinus.rst
+++ b/school/source/abitur/de/2015_sinus.rst
@@ -1,21 +1,23 @@
 Bayerisches Abitur in Mathematik 2015
 -------------------------------------
 
-Gegeben ist die in :math:`\mathbb{R}` definierte Funktion
-:math:`f: x\mapsto \sin(2x)`. Geben Sie Amplitude, Periode und Wertemenge der
-Funktion :math:`f` an.
+.. admonition:: Aufgabe
 
-.. admonition:: Lösung
+  Gegeben ist die in :math:`\mathbb{R}` definierte Funktion
+  :math:`f: x\mapsto \sin(2x)`. Geben Sie Amplitude, Periode und Wertemenge der
+  Funktion :math:`f` an.
 
-  Die Sinusfunktion hat die Amplitude 1, Periode :math:`2\pi` und den
-  Wertebereich :math:`[-1, 1]`. Die gegebene Funktion :math:`f` hat die gleiche
-  Amplitude und den gleichen Wertebereich. Aufgrund des Faktors 2 im Argument
-  ist die Periode allerdings nur :math:`\pi`.
-  
-  Wir können diese Aussagen mit Sage überprüfen:
-  
-  .. sagecellserver::
-  
-       sage: plot(sin(2*x), (0, 2*pi), figsize=(4, 2.5))
-  
-  .. end of output
+**Lösung**
+
+Die Sinusfunktion hat die Amplitude 1, Periode :math:`2\pi` und den
+Wertebereich :math:`[-1, 1]`. Die gegebene Funktion :math:`f` hat die gleiche
+Amplitude und den gleichen Wertebereich. Aufgrund des Faktors 2 im Argument
+ist die Periode allerdings nur :math:`\pi`.
+
+Wir können diese Aussagen mit Sage überprüfen:
+
+.. sagecellserver::
+
+     sage: plot(sin(2*x), (0, 2*pi), figsize=(4, 2.5))
+
+.. end of output

--- a/school/source/abitur/de/2015_talkshow.rst
+++ b/school/source/abitur/de/2015_talkshow.rst
@@ -1,76 +1,78 @@
 Bayerisches Abitur in Mathematik 2015
 -------------------------------------
 
-Ein Moderator lädt zu seiner Talkshow drei Politiker, eine Journalistin und
-zwei Mitglieder einer Bürgerinitiative ein. Für die Diskussionsrunde ist eine
-halbkreisförmige Sitzordnung vorgesehen, bei der nach den Personen
-unterschieden wird und der Moderator den mittleren Platz einnimmt.
+.. admonition:: Aufgabe
 
-a) Geben Sie einen Term an, mit dem die Anzahl der möglichen Sitzordnungen
-berechnet werden kann, wenn keine weiteren Einschränkungen berücksichtigt
-werden.
+  Ein Moderator lädt zu seiner Talkshow drei Politiker, eine Journalistin und
+  zwei Mitglieder einer Bürgerinitiative ein. Für die Diskussionsrunde ist eine
+  halbkreisförmige Sitzordnung vorgesehen, bei der nach den Personen
+  unterschieden wird und der Moderator den mittleren Platz einnimmt.
 
-.. admonition:: Lösung
+  a) Geben Sie einen Term an, mit dem die Anzahl der möglichen Sitzordnungen
+     berechnet werden kann, wenn keine weiteren Einschränkungen berücksichtigt
+     werden.
 
-  Wenn wir alle möglichen Sitzverteilungen erzeugen wollen, haben wir für den
-  ersten Platz die Wahl unter 6 Personen, für den zweiten Platz bleibt noch die
-  Wahl zwischen 5 Personen, usw. Insgesamt gibt es also
-  
-  .. math::
-  
-     6!=6\cdot5\cdot4\cdot3\cdot2\cdot1=720
-  
-  Möglichkeiten.
-  
-  Bezeichnen wir den Moderator mit M, die Politiker mit 1, 2 und 3, die
-  Journalistin mit J und die Mitglieder der Bürgerinitiative mit B und b, so
-  können wir alle Sitzordnungen auflisten:
-  
-  .. sagecellserver::
-  
-      sage: for n, a in enumerate(Arrangements(["1", "2", "3", "J", "B", "b"], 6)):
-      ...       if not n % 8:
-      ...           print "%3i" % (n/8+1),
-      ...       print "%sM%s" % ("".join(a[:3]), "".join(a[3:])),
-      ...       if not (n+1) % 8:
-      ...           print
-  
-  .. end of output
-  
-  Unsere Liste umfasst tatsächlich :math:`8\cdot90=720` verschiedene
-  Sitzordnungen.
+  b) Der Sender hat festgelegt, dass unmittelbar neben dem Moderator auf einer
+     Seite die Journalistin und auf der anderen Seite einer der Politiker sitzen
+     soll. Berechnen Sie unter Berücksichtigung dieser weiteren Einschränkung
+     die Anzahl der möglichen Sitzordnungen.
 
-b) Der Sender hat festgelegt, dass unmittelbar neben dem Moderator auf einer
-   Seite die Journalistin und auf der anderen Seite einer der Politiker sitzen
-   soll. Berechnen Sie unter Berücksichtigung dieser weiteren Einschränkung
-   die Anzahl der möglichen Sitzordnungen.
+**Lösung zu Teil a**
 
-.. admonition:: Lösung
+Wenn wir alle möglichen Sitzverteilungen erzeugen wollen, haben wir für den
+ersten Platz die Wahl unter 6 Personen, für den zweiten Platz bleibt noch die
+Wahl zwischen 5 Personen, usw. Insgesamt gibt es also
 
-  Bei der Besetzung der Stühle können wir zum Beispiel folgendermaßen vorgehen:
-  Die Journalistin bekommt einen der beiden Stühle (2 Möglichkeiten), den anderen 
-  Stuhl erhält dann einer der drei Politiker (3 Möglichkeiten), so dass noch vier 
-  Personen auf die restlichen Stühle zu verteilen sind (in Analogie zur
-  Überlegung aus Teilaufgabe a ergibt das :math:`4\cdot3\cdot2\cdot1=24`
-  Möglichkeiten). Damit ergeben sich insgesamt :math:`2\cdot3\cdot24`
-  Sitzordnungen. Diese können wir wiederum auflisten:
-  
-  .. sagecellserver::
-  
-      sage: persons = set(["1", "2", "3", "B", "b"])
-      sage: n = 0
-      ...   for jleft in (True, False):
-      ...       for pmiddle in ("1", "2", "3"): 
-      ...           for others in Arrangements(persons-set([pmiddle]), 4):
-      ...               if jleft:
-      ...                   a = "".join(others[:2])+"JM"+pmiddle+"".join(others[2:])
-      ...               else:
-      ...                   a = "".join(others[:2])+pmiddle+"MJ"+"".join(others[2:])
-      ...               if not n % 8:
-      ...                   print "%3i" % (n/8+1),
-      ...               print a,
-      ...               if not (n+1) % 8:
-      ...                   print
-      ...               n = n+1
-  
-  Wie erwartet erhalten wir :math:`18\cdot8=144` Sitzordnungen.
+.. math::
+
+   6!=6\cdot5\cdot4\cdot3\cdot2\cdot1=720
+
+Möglichkeiten.
+
+Bezeichnen wir den Moderator mit M, die Politiker mit 1, 2 und 3, die
+Journalistin mit J und die Mitglieder der Bürgerinitiative mit B und b, so
+können wir alle Sitzordnungen auflisten:
+
+.. sagecellserver::
+
+    sage: for n, a in enumerate(Arrangements(["1", "2", "3", "J", "B", "b"], 6)):
+    ...       if not n % 8:
+    ...           print "%3i" % (n/8+1),
+    ...       print "%sM%s" % ("".join(a[:3]), "".join(a[3:])),
+    ...       if not (n+1) % 8:
+    ...           print
+
+.. end of output
+
+Unsere Liste umfasst tatsächlich :math:`8\cdot90=720` verschiedene
+Sitzordnungen.
+
+**Lösung zu Teil b**
+
+Bei der Besetzung der Stühle können wir zum Beispiel folgendermaßen vorgehen:
+Die Journalistin bekommt einen der beiden Stühle (2 Möglichkeiten), den anderen 
+Stuhl erhält dann einer der drei Politiker (3 Möglichkeiten), so dass noch vier 
+Personen auf die restlichen Stühle zu verteilen sind (in Analogie zur
+Überlegung aus Teilaufgabe a ergibt das :math:`4\cdot3\cdot2\cdot1=24`
+Möglichkeiten). Damit ergeben sich insgesamt :math:`2\cdot3\cdot24`
+Sitzordnungen. Diese können wir wiederum auflisten:
+
+.. sagecellserver::
+
+    sage: persons = set(["1", "2", "3", "B", "b"])
+    sage: n = 0
+    ...   for jleft in (True, False):
+    ...       for pmiddle in ("1", "2", "3"): 
+    ...           for others in Arrangements(persons-set([pmiddle]), 4):
+    ...               if jleft:
+    ...                   a = "".join(others[:2])+"JM"+pmiddle+"".join(others[2:])
+    ...               else:
+    ...                   a = "".join(others[:2])+pmiddle+"MJ"+"".join(others[2:])
+    ...               if not n % 8:
+    ...                   print "%3i" % (n/8+1),
+    ...               print a,
+    ...               if not (n+1) % 8:
+    ...                   print
+    ...               n = n+1
+
+Wie erwartet erhalten wir :math:`18\cdot8=144` Sitzordnungen.

--- a/school/source/abitur/en/2015_biathlon.rst
+++ b/school/source/abitur/en/2015_biathlon.rst
@@ -1,82 +1,84 @@
 Bavarian final secondary-school examinations in mathematics 2015
 ================================================================
 
-In the winter sport biathlon, during each shooting round, five targets have
-to be hit. In the course of an individual race, a biathlet executes a shooting
-round by shooting on each target once. This shooting round is modeled by
-a Bernoulli chain of length 5 with a probablity :math:`p` to score a hit.
+.. admonition:: Problem
 
-a) Give an expressions for the following events A and B which described the
-   probability for the event as a function of math:`p`.
- | A: „The biathlete scores exactly four hits.“   
- | B: „The biathlete scores a hit only for the first two shots.“
+  In the winter sport biathlon, during each shooting round, five targets have
+  to be hit. In the course of an individual race, a biathlet executes a shooting
+  round by shooting on each target once. This shooting round is modeled by
+  a Bernoulli chain of length 5 with a probablity :math:`p` to score a hit.
 
-.. admonition:: Solution
+  a) Give an expressions for the following events A and B which described the
+     probability for the event as a function of :math:`p`.
+   | A: „The biathlete scores exactly four hits.“   
+   | B: „The biathlete scores a hit only for the first two shots.“
 
-  We start by considering the probability for event B. Since the probability
-  of a hit is given by math:`p`, the probability for a miss equals :math:`1-p`. 
-  Correspondingly, the probability for scoring a hit for exactly the first two
-  shots is obtained as :math:`p^2(1-p)^3`. We check this statement by means of
-  simulation. However, we should not expect perfect agreement.
-  
-  .. sagecellserver::
-  
-      sage: p = 0.7
-      sage: rounds = 1000000
-      sage: goal = [True, True, False, False, False]
-      sage: successes = 0
-      sage: for round in range(rounds):
-      ...       result = [random() < p for _ in range(5)]
-      ...       if result == goal:
-      ...           successes = successes+1
-      sage: print N(successes/rounds), p^2*(1-p)^3
-  
-  .. end of output
-  
-  Let us now consider event A. In analogy to the previous consideration, the
-  probability for a given sequence of four hits and and one miss equals
-  :math:`p^4(1-p)`. However, the shot which misses is not fixed. The number of
-  possibilites to distribute :math:`M` events on :math:`N` positions is given
-  by the binomial coefficient
-  
-  .. math::
-  
-     \binom{N}{M} = \frac{N!}{M!(N-M)!}.
-  
-  In our case, the desired probability is obtained as
-  
-  .. math::
-  
-     \binom{5}{4}p^4(1-p) = 5p^4(1-p).
-  
-  After briefly verifying the binomial coefficient of which we make use here
-  
-  .. sagecellserver::
-  
-      sage: binomial(5, 4)
-  
-  .. end of output
-  
-  we once more check our result for the probability by means of a simulation:
-  
-  .. sagecellserver::
-  
-      sage: p = 0.7
-      sage: rounds = 1000000
-      sage: successes = 0
-      sage: for round in range(rounds):
-      ...       result = [random() < p for _ in range(5)]
-      ...       if sum(result) == 4:
-      ...           successes = successes+1
-      sage: print N(successes/rounds), 5*p^4*(1-p)
-  
-  .. end of output
+  b) Explain by way of example why modeling a shooting round by means of
+     a Bernoulli chain might disagree with reality.
 
-b) Explain by way of example why modeling a shooting round by means of
-   a Bernoulli chain might disagree with reality.
+**Solution of part a**
 
-.. admonition:: Solution
+We start by considering the probability for event B. Since the probability
+of a hit is given by math:`p`, the probability for a miss equals :math:`1-p`. 
+Correspondingly, the probability for scoring a hit for exactly the first two
+shots is obtained as :math:`p^2(1-p)^3`. We check this statement by means of
+simulation. However, we should not expect perfect agreement.
 
-  The Bernoulli chain assumes that the probability of a hit is the same for
-  each shot. However, in reality the probability of a hit might for example
-  decrease after a miss.
+.. sagecellserver::
+
+    sage: p = 0.7
+    sage: rounds = 1000000
+    sage: goal = [True, True, False, False, False]
+    sage: successes = 0
+    sage: for round in range(rounds):
+    ...       result = [random() < p for _ in range(5)]
+    ...       if result == goal:
+    ...           successes = successes+1
+    sage: print N(successes/rounds), p^2*(1-p)^3
+
+.. end of output
+
+Let us now consider event A. In analogy to the previous consideration, the
+probability for a given sequence of four hits and and one miss equals
+:math:`p^4(1-p)`. However, the shot which misses is not fixed. The number of
+possibilites to distribute :math:`M` events on :math:`N` positions is given
+by the binomial coefficient
+
+.. math::
+
+   \binom{N}{M} = \frac{N!}{M!(N-M)!}.
+
+In our case, the desired probability is obtained as
+
+.. math::
+
+   \binom{5}{4}p^4(1-p) = 5p^4(1-p).
+
+After briefly verifying the binomial coefficient of which we make use here
+
+.. sagecellserver::
+
+    sage: binomial(5, 4)
+
+.. end of output
+
+we once more check our result for the probability by means of a simulation:
+
+.. sagecellserver::
+
+    sage: p = 0.7
+    sage: rounds = 1000000
+    sage: successes = 0
+    sage: for round in range(rounds):
+    ...       result = [random() < p for _ in range(5)]
+    ...       if sum(result) == 4:
+    ...           successes = successes+1
+    sage: print N(successes/rounds), 5*p^4*(1-p)
+
+.. end of output
+
+**Solution of part b**
+
+The Bernoulli chain assumes that the probability of a hit is the same for
+each shot. However, in reality the probability of a hit might for example
+decrease after a miss.

--- a/school/source/abitur/en/2015_funktionen.rst
+++ b/school/source/abitur/en/2015_funktionen.rst
@@ -1,68 +1,70 @@
 Bavarian final secondary-school examinations in mathematics 2015
 ================================================================
 
-Given are the functions :math:`f, g` and :math:`h` defined on :math:`\mathbb{R}`
-by :math:`f(x)=x^2-x+1`, :math:`g(x)=x^3-x+1`, and :math:`h(x)=x^4+x^2+1`.
+.. admonition:: Problem
 
-a) The figure depicts the graph of one of the three functions. Indicate which
-   functions is represented by the graph. Argue why the graph cannot represent
-   the other two functions.
+  Given are the functions :math:`f, g` and :math:`h` defined on :math:`\mathbb{R}`
+  by :math:`f(x)=x^2-x+1`, :math:`g(x)=x^3-x+1`, and :math:`h(x)=x^4+x^2+1`.
 
-.. image:: figs/abiturpruefung_mathematik_cas_2015_pruefungsteil_a_1_2_a.png
-   :align: center
+  a) The figure depicts the graph of one of the three functions. Indicate which
+     functions is represented by the graph. Argue why the graph cannot represent
+     the other two functions.
 
-.. admonition:: Solution
+  .. image:: ../figs/abiturpruefung_mathematik_cas_2015_pruefungsteil_a_1_2_a.png
+     :align: center
 
-  The graph displays two extrema. Therefore, it cannot represent the function
-  :math:`f(x)` because the derivative of a quadratic function possesses only
-  one zero. Furthermore, the function displayes in the figure takes on negative
-  values, excluding the function :math:`h(x)` aus. As a consequence the graph
-  represents the function :math:`g(x)`. We check our conjecture with the help
-  of Sage:
-  
-  .. sagecellserver::
-  
-      sage: ranges = {'xmin': -2, 'xmax': 2.5, 'ymin': -2.5, 'ymax': 2.5}
-      sage: p = sum([plot(x^2-x+1, color='blue', **ranges),
-      ...            plot(x^3-x+1, color='red', **ranges),
-      ...            plot(x^4+x^2+1, color='green', **ranges)])
-      sage: p.show(figsize=(2.7, 3))
-  
-  .. end of output
-  
-  The graph of the function :math:`g(x)` shown in red indeed fits the graph
-  in the original figure.
+  b) The first derivative of the function :math:`h` is given by :math:`h'`.
+     Evalute :math:`\int_0^1h'(x)\mathrm{d}x`.
 
-b) The first derivative of the function :math:`h` is given by :math:`h'`.
-   Evalute :math:`\int_0^1h'(x)\mathrm{d}x`.
+**Solution of part a**
 
-.. admonition:: Solution
+The graph displays two extrema. Therefore, it cannot represent the function
+:math:`f(x)` because the derivative of a quadratic function possesses only
+one zero. Furthermore, the function displayes in the figure takes on negative
+values, excluding the function :math:`h(x)` aus. As a consequence the graph
+represents the function :math:`g(x)`. We check our conjecture with the help
+of Sage:
 
-  The antiderivative of the derivative of a function is the function itself.
-  It follows
-  
-  .. math::
-  
-     \int_0^1h'(x)\mathrm{d}x = h(1)-h(0) = 3-1 = 2.
-  
-  In Sage, we start by differentiating the function :math:`h(x)` as a check
-  and continue by evaluating the required definite integral:
-  
-  .. sagecellserver::
-  
-      sage: h(x) = x^4+x^2+1
-      sage: dh(x) = diff(h, x)
-      sage: print 'Derivative of h(x):', dh
-      sage: print 'Value of the definite integral:', integrate(dh(x), x, 0, 1)
-  
-  .. end of output
-  
-  Of course, according to our reasoning above, we obtain the same result by
-  subtracting the function taken at the limits of integration:
-  
-  .. sagecellserver::
-  
-      sage: h(x) = x^4+x^2+1
-      sage: h(1)-h(0)
-  
-  .. end of output
+.. sagecellserver::
+
+    sage: ranges = {'xmin': -2, 'xmax': 2.5, 'ymin': -2.5, 'ymax': 2.5}
+    sage: p = sum([plot(x^2-x+1, color='blue', **ranges),
+    ...            plot(x^3-x+1, color='red', **ranges),
+    ...            plot(x^4+x^2+1, color='green', **ranges)])
+    sage: p.show(figsize=(2.7, 3))
+
+.. end of output
+
+The graph of the function :math:`g(x)` shown in red indeed fits the graph
+in the original figure.
+
+**Solution of part b**
+
+The antiderivative of the derivative of a function is the function itself.
+It follows
+
+.. math::
+
+   \int_0^1h'(x)\mathrm{d}x = h(1)-h(0) = 3-1 = 2.
+
+In Sage, we start by differentiating the function :math:`h(x)` as a check
+and continue by evaluating the required definite integral:
+
+.. sagecellserver::
+
+    sage: h(x) = x^4+x^2+1
+    sage: dh(x) = diff(h, x)
+    sage: print 'Derivative of h(x):', dh
+    sage: print 'Value of the definite integral:', integrate(dh(x), x, 0, 1)
+
+.. end of output
+
+Of course, according to our reasoning above, we obtain the same result by
+subtracting the function taken at the limits of integration:
+
+.. sagecellserver::
+
+    sage: h(x) = x^4+x^2+1
+    sage: h(1)-h(0)
+
+.. end of output

--- a/school/source/abitur/en/2015_funktionenschar.rst
+++ b/school/source/abitur/en/2015_funktionenschar.rst
@@ -1,37 +1,39 @@
 Bavarian final secondary-school examinations in mathematics 2015
 ================================================================
 
-We are given the set of functions :math:`f_a : x\mapsto x\mathrm{e}^{ax}`
-defined on :math:`\mathbb{R}` with :math:`a\in\mathbb{R}\backslash\{0\}`.
-Determine the value of :math:`a` for which the derivative of :math:`f_a` at 
-:math:`x=2` vanishes.
+.. admonition:: Problem
 
-.. admonition:: Solution
+  We are given the set of functions :math:`f_a : x\mapsto x\mathrm{e}^{ax}`
+  defined on :math:`\mathbb{R}` with :math:`a\in\mathbb{R}\backslash\{0\}`.
+  Determine the value of :math:`a` for which the derivative of :math:`f_a` at 
+  :math:`x=2` vanishes.
 
-  The derivative of the given function is obtained as
-  
-  .. math::
-  
-     \frac{\mathrm{d}f_a}{\mathrm{d}x} = (1+ax)\mathrm{e}^{ax}
-  
-  so that
-  
-  .. math::
-  
-     \left.\frac{\mathrm{d}f_a}{\mathrm{d}x}\right\vert_{x=2} =
-      (1+2a)\mathrm{e}^{2a}.
-  
-  As a consquence, the derivate vanishes provided :math:`1+2a=0`, i.e. for
-  :math:`a=-1/2`.
-  
-  This calculation can be checked by means of Sage:
-  
-  .. sagecellserver::
-  
-      sage: a = var('a')
-      sage: f(x, a) = x*exp(a*x)
-      sage: df = f.derivative(x)
-      sage: print 'Derivative of f:', df
-      sage: solve(df(2, a) == 0, a)
-  
-  .. end of output
+**Solution**
+
+The derivative of the given function is obtained as
+
+.. math::
+
+   \frac{\mathrm{d}f_a}{\mathrm{d}x} = (1+ax)\mathrm{e}^{ax}
+
+so that
+
+.. math::
+
+   \left.\frac{\mathrm{d}f_a}{\mathrm{d}x}\right\vert_{x=2} =
+    (1+2a)\mathrm{e}^{2a}.
+
+As a consquence, the derivate vanishes provided :math:`1+2a=0`, i.e. for
+:math:`a=-1/2`.
+
+This calculation can be checked by means of Sage:
+
+.. sagecellserver::
+
+    sage: a = var('a')
+    sage: f(x, a) = x*exp(a*x)
+    sage: df = f.derivative(x)
+    sage: print 'Derivative of f:', df
+    sage: solve(df(2, a) == 0, a)
+
+.. end of output

--- a/school/source/abitur/en/2015_funktionseigenschaften.rst
+++ b/school/source/abitur/en/2015_funktionseigenschaften.rst
@@ -1,64 +1,66 @@
 Bavarian final secondary-school examinations in mathematics 2015
 ================================================================
 
-For each of the following sets of requirements name a function satisfying them.
+.. admonition:: Problem
 
-a) The function :math:`g` has a maximum domain given by :math:`]-\infty; 5]`.
+  For each of the following sets of requirements name a function satisfying them.
 
-.. admonition:: Solution
+  a) The function :math:`g` has a maximum domain given by :math:`]-\infty; 5]`.
 
-  A function with domain :math:`[0; \infty[` is given by
-  :math:`x\mapsto\sqrt{x}`. Therefore, :math:`g(x)=\sqrt{5-x}` is one of the
-  functions with the given domain.
+  b) The function :math:`k` has a zero at :math:`x=2` as well as pole at
+     :math:`x=-3` without changing its sign. The graph of :math:`k` has an
+     asymptote the straight line given by :math:`y=1` als Asymptote.
 
-b) The function :math:`k` has a zero at :math:`x=2` as well as pole at
-   :math:`x=-3` without changing its sign. The graph of :math:`k` has an
-   asymptote the straight line given by :math:`y=1` als Asymptote.
+**Solution of part a**
 
-.. admonition:: Solution
+A function with domain :math:`[0; \infty[` is given by
+:math:`x\mapsto\sqrt{x}`. Therefore, :math:`g(x)=\sqrt{5-x}` is one of the
+functions with the given domain.
 
-  The function :math:`k(x)` can be chosen as rational function. Beacuase of
-  the zero at :math:`x=2` the numerator must contain at least a factor
-  :math:`x-2`. The pole at :math:`x=-3` without change of sign is obtained
-  by means of a factor :math:`(x+3)^2` in the denominator. In order to obtain
-  the desired asymptotic behavior for :math:`\vert x\vert\to\infty`, the factor
-  in the numerator must be squares. We thus arrive at
-  
-  .. math::
-  
-     k(x)=\frac{(x-2)^2}{(x+3)^2}.
-  
-  We demonstrate with the help of Sage that this function indeed has the
-  required properties.
-  
-  Zero at :math:`x=2`:
-  
-  .. sagecellserver::
-  
-      sage: k(x) = ((x-2)/(x+3))^2
-      sage: plot(k, xmin=0, xmax=4, ymin=-0.1, ymax=0.5, figsize=(4, 2.5))
-  
-  .. end of output
-  
-  Pole at :math:`x=-3` without change of sign:
-  
-  .. sagecellserver::
-  
-      sage: k(x) = ((x-2)/(x+3))^2
-      sage: plot(k, xmin=-6, xmax=0, ymin=0, ymax=1000, figsize=(4, 2.5))
-  
-  .. end of output
-  
-  Asymptotic approach to the straight line :math:`y=1` for
-  :math:`\vert x\vert\to 1`:
-  
-  .. sagecellserver::
-  
-      sage: k(x) = ((x-2)/(x+3))^2
-      sage: xmax = 1000
-      sage: xmin = -xmax
-      sage: p = plot(k, xmin=xmin, xmax=xmax, ymin=0.5, ymax=1.5)
-      sage: p = p+line([(xmin, 1), (xmax, 1)], linestyle='dashed')
-      sage: p.show(figsize=(4, 2.5))
-  
-  .. end of output
+**Solution of part b**
+
+The function :math:`k(x)` can be chosen as rational function. Beacuase of
+the zero at :math:`x=2` the numerator must contain at least a factor
+:math:`x-2`. The pole at :math:`x=-3` without change of sign is obtained
+by means of a factor :math:`(x+3)^2` in the denominator. In order to obtain
+the desired asymptotic behavior for :math:`\vert x\vert\to\infty`, the factor
+in the numerator must be squares. We thus arrive at
+
+.. math::
+
+   k(x)=\frac{(x-2)^2}{(x+3)^2}.
+
+We demonstrate with the help of Sage that this function indeed has the
+required properties.
+
+Zero at :math:`x=2`:
+
+.. sagecellserver::
+
+    sage: k(x) = ((x-2)/(x+3))^2
+    sage: plot(k, xmin=0, xmax=4, ymin=-0.1, ymax=0.5, figsize=(4, 2.5))
+
+.. end of output
+
+Pole at :math:`x=-3` without change of sign:
+
+.. sagecellserver::
+
+    sage: k(x) = ((x-2)/(x+3))^2
+    sage: plot(k, xmin=-6, xmax=0, ymin=0, ymax=1000, figsize=(4, 2.5))
+
+.. end of output
+
+Asymptotic approach to the straight line :math:`y=1` for
+:math:`\vert x\vert\to 1`:
+
+.. sagecellserver::
+
+    sage: k(x) = ((x-2)/(x+3))^2
+    sage: xmax = 1000
+    sage: xmin = -xmax
+    sage: p = plot(k, xmin=xmin, xmax=xmax, ymin=0.5, ymax=1.5)
+    sage: p = p+line([(xmin, 1), (xmax, 1)], linestyle='dashed')
+    sage: p.show(figsize=(4, 2.5))
+
+.. end of output

--- a/school/source/abitur/en/2015_nullstellen_log.rst
+++ b/school/source/abitur/en/2015_nullstellen_log.rst
@@ -1,32 +1,34 @@
 Bavarian final secondary-school examinations in mathematics 2015
 ================================================================
 
-Determine the solutions of :math:`(4x-3)\cdot\ln\left(x^2-5x+7\right)=0` for
-:math:`x\in\mathbb{R}`.
+.. admonition:: Problem
 
-.. admonition:: Solution
+  Determine the solutions of :math:`(4x-3)\cdot\ln\left(x^2-5x+7\right)=0` for
+  :math:`x\in\mathbb{R}`.
 
-  The zeros of the function on the left-hand side are determined by the zeros
-  of the two factors.
+**Solution**
 
-  Solving the requirement :math:`4x-3=0` for :math:`x` immediately yields the
-  first zero :math:`x_1 = 3/4`.
+The zeros of the function on the left-hand side are determined by the zeros
+of the two factors.
 
-  The second factor vanishes provided the argument of the logarithm equals one.
-  One thus needs to find solutions of :math:`x^2-5x+7=1`. The solutions of
-  the resulting quadratic equation :math:`x^2-5x+6=0` are obtained by means of
+Solving the requirement :math:`4x-3=0` for :math:`x` immediately yields the
+first zero :math:`x_1 = 3/4`.
 
-  .. math::
+The second factor vanishes provided the argument of the logarithm equals one.
+One thus needs to find solutions of :math:`x^2-5x+7=1`. The solutions of
+the resulting quadratic equation :math:`x^2-5x+6=0` are obtained by means of
 
-     x_{2,3} = \frac{5\pm\sqrt{25-24}}{2}.
+.. math::
 
-  We thus obtain two more zeros :math:`x_2=2` and :math:`x_3=3`.
+   x_{2,3} = \frac{5\pm\sqrt{25-24}}{2}.
 
-  These results can easily be checked with Sage:
+We thus obtain two more zeros :math:`x_2=2` and :math:`x_3=3`.
 
-  .. sagecellserver::
+These results can easily be checked with Sage:
 
-    sage: x = var('x')
-    sage: solve((4*x-3)*ln(x^2-5*x+7) == 0, x)
+.. sagecellserver::
 
-  .. end of output
+  sage: x = var('x')
+  sage: solve((4*x-3)*ln(x^2-5*x+7) == 0, x)
+
+.. end of output

--- a/school/source/abitur/en/2015_parallelogramm.rst
+++ b/school/source/abitur/en/2015_parallelogramm.rst
@@ -1,93 +1,95 @@
 Bavarian final secondary-school examinations in mathematics 2015
 ================================================================
 
-A straight line g goes through the points A(0|1|2) and B(2|5|6).
+.. admonition:: Problem
 
-a) Demonstrate that the distance between points A and B is 6. The points C and D
-   lie on g and have each the distance 12 from A. Determine the coordinates of
-   C and D.
+  A straight line :math:`g` goes through the points A(0|1|2) and B(2|5|6).
 
-.. admonition:: Solution
+  a) Demonstrate that the distance between points A and B is 6. The points C
+     and D lie on :math:`g` and have each the distance 12 from A. Determine the
+     coordinates of C and D.
 
-  The vector connecting points A and B has the coordinates (2, 4, 4). Its length
-  is therefore given by :math:`\sqrt{2^2+4^2+4^2}=\sqrt{36}=6`. The points C and
-  D can be obtained by adding or subtracting twice the vector from A to B to the
-  position vector of A. We thus obtain the points C (4|9|10) and D(-4|-7|-6).
-  
-  We now implement this reasoning in Sage. First we calculate the distance between
-  points A and B. then we determine the coordinates of points C and D. Finally,
-  we verify that the distance between points C and D on the one hand and the
-  point A on the other hand equals indeed 12.
+  b) The points A, B and E(1|2|5) together with one more point shall form the
+     vertices of a parallelogram. There exist several possibilities for the
+     position of the fourth vertex. State the coordinates of two of the possible
+     fourth vertices.
 
-  .. sagecellserver::
-  
-      sage: a = vector([0, 1, 2])
-      sage: b = vector([2, 5, 6])
-      sage: print 'Length of vector from A to B:', norm(b-a)
-      sage: c = a+2*(b-a)
-      sage: d = a-2*(b-a)
-      sage: print 'Coordinates of C:', c
-      sage: print 'Coordinates of D:', d
-      sage: print 'Distance of points A and C:', norm(c-a)
-      sage: print 'Distance of points A and D:', norm(d-a)
-  
-  .. end of output
+**Solution of part a**
 
-b) The points A, B and E(1|2|5) together with one more point shall form the
-   vertices of a parallelogram. There exist several possibilities for the
-   position of the fourth vertex. State the coordinates of two of the possible
-   fourth vertices.
+The vector connecting points A and B has the coordinates (2, 4, 4). Its length
+is therefore given by :math:`\sqrt{2^2+4^2+4^2}=\sqrt{36}=6`. The points C and
+D can be obtained by adding or subtracting twice the vector from A to B to the
+position vector of A. We thus obtain the points C (4|9|10) and D(-4|-7|-6).
 
-.. admonition:: Solution
+We now implement this reasoning in Sage. First we calculate the distance between
+points A and B. then we determine the coordinates of points C and D. Finally,
+we verify that the distance between points C and D on the one hand and the
+point A on the other hand equals indeed 12.
 
-  Choosing two of three possible vectors between the given points, one adds
-  one vector to the end of the other one to obtain the fourth point.
-  
-  We start by using the vector from A to B and from A to E:
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 1, 2])
-      sage: b = vector([2, 5, 6])
-      sage: e = vector([1, 2, 5])
-      sage: a_to_b = b-a
-      sage: a_to_e = e-a
-      sage: f1 = b+a_to_e
-      sage: f2 = e+a_to_b
-      sage: f1, f2
-  
-  .. end of output
-  
-  The two ways to obtain the fourth vertex F yield the same result as it should
-  be. One possible fourth vertex therefore is given by F(3|6|9).
-  
-  Another parallelogram is obtained, if point B as being diagonally opposite to
-  the new point.
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 1, 2])
-      sage: b = vector([2, 5, 6])
-      sage: e = vector([1, 2, 5])
-      sage: b_to_a = a-b
-      sage: b_to_e = e-b
-      sage: f1 = a+b_to_e
-      sage: f2 = e+b_to_a
-      sage: f1, f2
-  
-  .. end of output
-  
-  For the sake of completeness we also determine the third possible vertex.
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 1, 2])
-      sage: b = vector([2, 5, 6])
-      sage: e = vector([1, 2, 5])
-      sage: e_to_a = a-e
-      sage: e_to_b = b-e
-      sage: f1 = a+e_to_b
-      sage: f2 = b+e_to_a
-      sage: f1, f2
+.. sagecellserver::
 
-  .. end of output
+    sage: a = vector([0, 1, 2])
+    sage: b = vector([2, 5, 6])
+    sage: print 'Length of vector from A to B:', norm(b-a)
+    sage: c = a+2*(b-a)
+    sage: d = a-2*(b-a)
+    sage: print 'Coordinates of C:', c
+    sage: print 'Coordinates of D:', d
+    sage: print 'Distance of points A and C:', norm(c-a)
+    sage: print 'Distance of points A and D:', norm(d-a)
+
+.. end of output
+
+**Solution of part b**
+
+Choosing two of three possible vectors between the given points, one adds
+one vector to the end of the other one to obtain the fourth point.
+
+We start by using the vector from A to B and from A to E:
+
+.. sagecellserver::
+
+    sage: a = vector([0, 1, 2])
+    sage: b = vector([2, 5, 6])
+    sage: e = vector([1, 2, 5])
+    sage: a_to_b = b-a
+    sage: a_to_e = e-a
+    sage: f1 = b+a_to_e
+    sage: f2 = e+a_to_b
+    sage: f1, f2
+
+.. end of output
+
+The two ways to obtain the fourth vertex F yield the same result as it should
+be. One possible fourth vertex therefore is given by F(3|6|9).
+
+Another parallelogram is obtained, if point B as being diagonally opposite to
+the new point.
+
+.. sagecellserver::
+
+    sage: a = vector([0, 1, 2])
+    sage: b = vector([2, 5, 6])
+    sage: e = vector([1, 2, 5])
+    sage: b_to_a = a-b
+    sage: b_to_e = e-b
+    sage: f1 = a+b_to_e
+    sage: f2 = e+b_to_a
+    sage: f1, f2
+
+.. end of output
+
+For the sake of completeness we also determine the third possible vertex.
+
+.. sagecellserver::
+
+    sage: a = vector([0, 1, 2])
+    sage: b = vector([2, 5, 6])
+    sage: e = vector([1, 2, 5])
+    sage: e_to_a = a-e
+    sage: e_to_b = b-e
+    sage: f1 = a+e_to_b
+    sage: f2 = b+e_to_a
+    sage: f1, f2
+
+.. end of output

--- a/school/source/abitur/en/2015_pyramide.rst
+++ b/school/source/abitur/en/2015_pyramide.rst
@@ -1,83 +1,85 @@
 Bavarian final secondary-school examinations in mathematics 2015
 ================================================================
 
-We consider the pyramid ABCDS with A(0|0|0), B(4|4|2), C(8|0|2), D(4|-4|0),
-and S(1|1|-4). Its base is a parallelogram.
+.. admonition:: Problem
 
-a) Prove that the parallelogram ABCD is a rectangle.
+  We consider the pyramid ABCDS with A(0|0|0), B(4|4|2), C(8|0|2), D(4|-4|0),
+  and S(1|1|-4). Its base is a parallelogram.
 
-.. admonition:: Solution
+  a) Prove that the parallelogram ABCD is a rectangle.
 
-  ABCD forms a rectangle if starting from one of the vertices the angle between
-  the shortest vectors to the othe vertices is a right angle.
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 0, 0])
-      sage: b = vector([4, 4, 2])
-      sage: c = vector([8, 0, 2])
-      sage: d = vector([4, -4, 0])
-      sage: print ' Distance A-B:', N(norm(b-a))
-      sage: print ' Distance A-C:', N(norm(c-a))
-      sage: print ' Distance A-D:', N(norm(d-a))
-      sage: (b-a).dot_product(d-a)
-  
-  .. end of output
-  
-  It follows that the vectors from A to B and from A to D are orthogonal
-  to each other. The point C lies diagonally opposite of A. Therfore, the
-  parallelogram is indeed a rectangle. Since this solution depends on the
-  information that ABCD is a parallelogram, we check alos the other three
-  inner angles.
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 0, 0])
-      sage: b = vector([4, 4, 2])
-      sage: c = vector([8, 0, 2])
-      sage: d = vector([4, -4, 0])
-      sage: (c-b).dot_product(a-b), (d-c).dot_product(b-c), (a-d).dot_product(c-d)
-  
-  .. end of output
+  b) The edge [AS] is normal to the base ABCD. The area of the base is
+     :math:`24\sqrt{2}`. Determine the volume of the pyramid.
 
-b) The edge [AS] is normal to the base ABCD. The area of the base is :math:`24\sqrt{2}`.
-   Determine the volume of the pyramid.
+**Solution of part a**
 
-.. admonition:: Solution
+ABCD forms a rectangle if starting from one of the vertices the angle between
+the shortest vectors to the othe vertices is a right angle.
 
-  Since the vector from A to S is normal to the base, its length :math:`h` equals
-  the height of the pyramid. The area of the base is given as :math:`A=24\sqrt{2}`.
-  We first briefly check the latter result.
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 0, 0])
-      sage: b = vector([4, 4, 2])
-      sage: d = vector([4, -4, 0])
-      sage: norm(a-b)*norm(a-d)
-  
-  .. end of output
-  
-  The height of the pyramid is obtained as
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 0, 0])
-      sage: s = vector([1, 1, -4])
-      sage: norm(s-a)
-  
-  .. end of output
-  
-  Then, volume takes on the value :math:`V=\frac{h}{3}A=48`. This result can be
-  confirmed directly with the help of Sage.
-  
-  .. sagecellserver::
-  
-      sage: a = vector([0, 0, 0])
-      sage: b = vector([4, 4, 2])
-      sage: c = vector([8, 0, 2])
-      sage: d = vector([4, -4, 0])
-      sage: s = vector([1, 1, -4])
-      sage: Polyhedron(vertices=[a, b, c, d, s]).volume()
-  
-  .. end of output
+.. sagecellserver::
+
+    sage: a = vector([0, 0, 0])
+    sage: b = vector([4, 4, 2])
+    sage: c = vector([8, 0, 2])
+    sage: d = vector([4, -4, 0])
+    sage: print ' Distance A-B:', N(norm(b-a))
+    sage: print ' Distance A-C:', N(norm(c-a))
+    sage: print ' Distance A-D:', N(norm(d-a))
+    sage: (b-a).dot_product(d-a)
+
+.. end of output
+
+It follows that the vectors from A to B and from A to D are orthogonal
+to each other. The point C lies diagonally opposite of A. Therfore, the
+parallelogram is indeed a rectangle. Since this solution depends on the
+information that ABCD is a parallelogram, we check alos the other three
+inner angles.
+
+.. sagecellserver::
+
+    sage: a = vector([0, 0, 0])
+    sage: b = vector([4, 4, 2])
+    sage: c = vector([8, 0, 2])
+    sage: d = vector([4, -4, 0])
+    sage: (c-b).dot_product(a-b), (d-c).dot_product(b-c), (a-d).dot_product(c-d)
+
+.. end of output
+
+**Solution of part b**
+
+Since the vector from A to S is normal to the base, its length :math:`h` equals
+the height of the pyramid. The area of the base is given as :math:`A=24\sqrt{2}`.
+We first briefly check the latter result.
+
+.. sagecellserver::
+
+    sage: a = vector([0, 0, 0])
+    sage: b = vector([4, 4, 2])
+    sage: d = vector([4, -4, 0])
+    sage: norm(a-b)*norm(a-d)
+
+.. end of output
+
+The height of the pyramid is obtained as
+
+.. sagecellserver::
+
+    sage: a = vector([0, 0, 0])
+    sage: s = vector([1, 1, -4])
+    sage: norm(s-a)
+
+.. end of output
+
+Then, volume takes on the value :math:`V=\frac{h}{3}A=48`. This result can be
+confirmed directly with the help of Sage.
+
+.. sagecellserver::
+
+    sage: a = vector([0, 0, 0])
+    sage: b = vector([4, 4, 2])
+    sage: c = vector([8, 0, 2])
+    sage: d = vector([4, -4, 0])
+    sage: s = vector([1, 1, -4])
+    sage: Polyhedron(vertices=[a, b, c, d, s]).volume()
+
+.. end of output

--- a/school/source/abitur/en/2015_sinus.rst
+++ b/school/source/abitur/en/2015_sinus.rst
@@ -1,19 +1,21 @@
 Bavarian final secondary-school examinations in mathematics 2015
 ================================================================
 
-We are given the function :math:`f: x\mapsto \sin(2x)` defined on
-:math:`\mathbb{R}`. What are the amplitude, period, and its range.
+.. admonition:: Problem
 
-.. admonition:: Solution
+  We are given the function :math:`f: x\mapsto \sin(2x)` defined on
+  :math:`\mathbb{R}`. What are the amplitude, period, and its range.
 
-  The sine function has amplitude 1, period :math:`2\pi` and the range
-  :math:`[-1, 1]`. The given function :math:`f` has the same amplitude and
-  range. Due the factor of 2 in the argument, its period is only :math:`\pi`.
-  
-  We can check these statements by means of Sage:
-  
-  .. sagecellserver::
-  
-       sage: plot(sin(2*x), (0, 2*pi), figsize=(4, 2.5))
-  
-  .. end of output
+**Solution**
+
+The sine function has amplitude 1, period :math:`2\pi` and the range
+:math:`[-1, 1]`. The given function :math:`f` has the same amplitude and
+range. Due the factor of 2 in the argument, its period is only :math:`\pi`.
+
+We can check these statements by means of Sage:
+
+.. sagecellserver::
+
+     sage: plot(sin(2*x), (0, 2*pi), figsize=(4, 2.5))
+
+.. end of output

--- a/school/source/abitur/en/2015_talkshow.rst
+++ b/school/source/abitur/en/2015_talkshow.rst
@@ -1,74 +1,76 @@
 Bavarian final secondary-school examinations in mathematics 2015
 ================================================================
 
-A talkshow host invites three politicians, a newswoman and two members of a
-citizens' action committee. During the discussion round, the participants
-will be sitting in a semi-circle with the host in the middle and each 
-participant taken as an individual.
+.. admonition:: Problem
 
-a) Give an expression which allows to determine the number of possible seating
-arrangements if no other constraints need to be taken into account.
+  A talkshow host invites three politicians, a newswoman and two members of a
+  citizens' action committee. During the discussion round, the participants
+  will be sitting in a semi-circle with the host in the middle and each 
+  participant taken as an individual.
 
-.. admonition:: Solution
+  a) Give an expression which allows to determine the number of possible seating
+     arrangements if no other constraints need to be taken into account.
 
-  If we want to generate all possible seating arrangements, we start with the
-  first seat for which we the choice among six person. For the second seat,
-  five person are left and so on. In total, we obtain
-  
-  .. math::
-  
-     6!=6\cdot5\cdot4\cdot3\cdot2\cdot1=720
-  
-  possibilities.
-  
-  If we indicate the host by H, the politicans by 1, 2, and 3, the newswoman
-  by N and the members of the citizens' action committee by C and c, we can
-  list all seating arrangements:
-  
-  .. sagecellserver::
-  
-      sage: for n, a in enumerate(Arrangements(["1", "2", "3", "N", "C", "c"], 6)):
-      ...       if not n % 8:
-      ...           print "%3i" % (n/8+1),
-      ...       print "%sH%s" % ("".join(a[:3]), "".join(a[3:])),
-      ...       if not (n+1) % 8:
-      ...           print
-  
-  .. end of output
-  
-  Our list indeed comprises :math:`8\cdot90=720` different seating
-  arrangements.
+  b) The station has decided that the newswoman will take a seat next to the
+     host and that to the other side of the host, a politician shall be seated.
+     Determine the number of possible seating arrangements accounting for these
+     constraints.
 
-b) The station has decided that the newswoman will take a seat next to the
-   host and that to the other side of the host, a politician shall be seated.
-   Determine the number of possible seating arrangements accounting for these
-   constraints.
+**Solution of part a**
 
-.. admonition:: Solution
+If we want to generate all possible seating arrangements, we start with the
+first seat for which we the choice among six person. For the second seat,
+five person are left and so on. In total, we obtain
 
-  We can attribute the seats by proceeding as follows: The newswoman is placed on
-  one of the two seats next to the host (2 possibilities) and one of the three
-  politicians is seated on the other side of the host (3 possibilities). It remains
-  to place four persons on four seats which, in analogy to our reasoning in part a,
-  yields :math:`4\cdot3\cdot2\cdot1=24` possiblities. In total, we obtain 
-  :math:`2\cdot3\cdot24` different seating arrangements which we can list:
-  
-  .. sagecellserver::
-  
-      sage: persons = set(["1", "2", "3", "B", "b"])
-      sage: n = 0
-      ...   for jleft in (True, False):
-      ...       for pmiddle in ("1", "2", "3"): 
-      ...           for others in Arrangements(persons-set([pmiddle]), 4):
-      ...               if jleft:
-      ...                   a = "".join(others[:2])+"JM"+pmiddle+"".join(others[2:])
-      ...               else:
-      ...                   a = "".join(others[:2])+pmiddle+"MJ"+"".join(others[2:])
-      ...               if not n % 8:
-      ...                   print "%3i" % (n/8+1),
-      ...               print a,
-      ...               if not (n+1) % 8:
-      ...                   print
-      ...               n = n+1
-  
-  We obtain :math:`18\cdot8=144` seating arrangements as expected.
+.. math::
+
+   6!=6\cdot5\cdot4\cdot3\cdot2\cdot1=720
+
+possibilities.
+
+If we indicate the host by H, the politicans by 1, 2, and 3, the newswoman
+by N and the members of the citizens' action committee by C and c, we can
+list all seating arrangements:
+
+.. sagecellserver::
+
+    sage: for n, a in enumerate(Arrangements(["1", "2", "3", "N", "C", "c"], 6)):
+    ...       if not n % 8:
+    ...           print "%3i" % (n/8+1),
+    ...       print "%sH%s" % ("".join(a[:3]), "".join(a[3:])),
+    ...       if not (n+1) % 8:
+    ...           print
+
+.. end of output
+
+Our list indeed comprises :math:`8\cdot90=720` different seating
+arrangements.
+
+**Solution of part b**
+
+We can attribute the seats by proceeding as follows: The newswoman is placed on
+one of the two seats next to the host (2 possibilities) and one of the three
+politicians is seated on the other side of the host (3 possibilities). It remains
+to place four persons on four seats which, in analogy to our reasoning in part a,
+yields :math:`4\cdot3\cdot2\cdot1=24` possiblities. In total, we obtain 
+:math:`2\cdot3\cdot24` different seating arrangements which we can list:
+
+.. sagecellserver::
+
+    sage: persons = set(["1", "2", "3", "C", "c"])
+    sage: n = 0
+    ...   for jleft in (True, False):
+    ...       for pmiddle in ("1", "2", "3"): 
+    ...           for others in Arrangements(persons-set([pmiddle]), 4):
+    ...               if jleft:
+    ...                   a = "".join(others[:2])+"NH"+pmiddle+"".join(others[2:])
+    ...               else:
+    ...                   a = "".join(others[:2])+pmiddle+"HN"+"".join(others[2:])
+    ...               if not n % 8:
+    ...                   print "%3i" % (n/8+1),
+    ...               print a,
+    ...               if not (n+1) % 8:
+    ...                   print
+    ...               n = n+1
+
+We obtain :math:`18\cdot8=144` seating arrangements as expected.


### PR DESCRIPTION
Since sagecells do not work well inside admonitions, the Abitur problem sets have been reformatted. In order to visually separate problem and solution, the problems are now set as admonition. In the matura problem sets, admonition plays a different role, so, ultimately, further changes will be needed. However, it seems appropriate to visually separate problem and solution. May be, another sphinx role should be defined?

Some minor errors in the translated version have been fixed as well.