### PR TITLE
Index of Abitur problems by subject

### DIFF
--- a/school/source/abitur/2013/en/intgraph.rst
+++ b/school/source/abitur/2013/en/intgraph.rst
@@ -5,7 +5,7 @@ Bavarian final secondary-school examinations in mathematics 2013
 
   Figure 1 displays the graph :math:`G_f` of a function :math:`f`
   defined in :math:`\mathbb{R}`. Sketch in figure 1 the graph of
-  the integral function :math:`F:x\mapsto \int\limits_1^x f(t)\mathrm{d}t`
+  the antiderivative function :math:`F:x\mapsto \int\limits_1^x f(t)\mathrm{d}t`
   defined in :math:`\mathbb{R}`. Consider with appropriate precision
   in particular the zeros and extrema of :math:`F` as well as :math:`F(0)`.
     

--- a/school/source/abitur/index_by_subject.rst
+++ b/school/source/abitur/index_by_subject.rst
@@ -1,0 +1,12 @@
+Bavarian final secondary-school examinations in mathematics
+===========================================================
+
+Index by subject
+................
+
+.. toctree::
+   :maxdepth: 1
+
+   Analysis <index_by_subject_analysis>
+   Geometry <index_by_subject_geometry>
+   Stochastics <index_by_subject_stochastics>

--- a/school/source/abitur/index_by_subject_analysis.rst
+++ b/school/source/abitur/index_by_subject_analysis.rst
@@ -7,36 +7,33 @@ Analysis
 .. toctree::
    :maxdepth: 1
 
-   Problem 1 <2013/en/sqrt>
-   Problem 2 <2013/en/wertemenge>
-   Problem 3 <2013/en/gleichungssystem>
-   Problem 4 <2013/en/intgraph>
-   Problem 5 <2013/en/kurvendiskussion>
-   Problem 6 <2013/en/ln>
-   Problem 7 <2013/en/xsinx>
-   Problem 8 <2013/en/schnittpunkt>
-   Problem 9 <2013/en/inthalbkreis>
-   Problem 10 <2013/en/asymp>
-
-   Problem 1 <2014/en/extremum>
-   Problem 2 <2014/en/stammfunktionen>
-   Problem 3 <2014/en/sinusfunktionen>
-   Problem 4 <2014/en/beispielfunktionen>
-   Problem 5 <2014/en/qualitative_integrale>
-   Problem 6 <2014/en/wendepunkte>
-   Problem 7 <2014/en/rechteck>
-   Problem 8 <2014/en/wurzelfunktion>
-   Problem 9 <2014/en/gebrochenrational>
-
-   Problem 1 <2015/en/nullstellen_log>
-   Problem 2 <2015/en/funktionen>
-   Problem 3 <2015/en/sinus>
-   Problem 4 <2015/en/funktionseigenschaften>
-   Problem 5 <2015/en/funktionenschar>
-   
-   Problem 1 <2016/en/logarithmus>
-   Problem 2 <2016/en/ungerades_integral>
-   Problem 3 <2016/en/kubische_funktion>
-   Problem 4 <2016/en/log_quad>
-   Problem 5 <2016/en/beispielfunktion>
-   Problem 6 <2016/en/qualitatives_integral>
+   Antiderivative of a function containing an exponential function <2014/en/stammfunktionen>
+   Antiderivative of an odd function <2016/en/ungerades_integral>
+   Area under two half circles <2013/en/inthalbkreis>
+   Cubic function <2016/en/kubische_funktion>
+   Derivative of a set of functions <2015/en/funktionenschar>
+   Function related to a partially filled cylinder <2013/en/asymp>
+   Function related to birth rate <2013/en/kurvendiskussion>
+   Functions with given codomain <2013/en/wertemenge>
+   Functions with specified properties I <2014/en/beispielfunktionen>
+   Functions with specified properties II <2015/en/funktionseigenschaften>
+   Functions with specified properties III <2016/en/beispielfunktion>
+   Graph of antiderivative <2013/en/intgraph>
+   Intersection of two functions <2013/en/schnittpunkt>
+   Logarithm <2013/en/ln>
+   Properties of a function containing a logarithm I <2014/en/extremum>
+   Properties of a function containing a logarithm II <2016/en/logarithmus>
+   Properties of a function containing a logarithm III <2016/en/log_quad>
+   Properties of a function containing a sine <2013/en/xsinx>
+   Properties of a function containing a square root <2014/en/wurzelfunktion>
+   Properties of a polynomial <2015/en/funktionen>
+   Properties of a rational function <2014/en/gebrochenrational>
+   Qualitative discussion of an antiderivative I <2014/en/qualitative_integrale>
+   Qualitative discussion of an antiderivative II <2016/en/qualitatives_integral>
+   Rectangle under a function <2014/en/rechteck>
+   Sine function <2015/en/sinus>
+   Sine functions <2014/en/sinusfunktionen>
+   Square root <2013/en/sqrt>
+   Turning points <2014/en/wendepunkte>
+   Zeros of a product of functions I <2013/en/gleichungssystem>
+   Zeros of a product of functions II <2015/en/nullstellen_log>

--- a/school/source/abitur/index_by_subject_analysis.rst
+++ b/school/source/abitur/index_by_subject_analysis.rst
@@ -1,0 +1,42 @@
+Bavarian final secondary-school examinations in mathematics
+===========================================================
+
+Analysis
+........
+
+.. toctree::
+   :maxdepth: 1
+
+   Problem 1 <2013/en/sqrt>
+   Problem 2 <2013/en/wertemenge>
+   Problem 3 <2013/en/gleichungssystem>
+   Problem 4 <2013/en/intgraph>
+   Problem 5 <2013/en/kurvendiskussion>
+   Problem 6 <2013/en/ln>
+   Problem 7 <2013/en/xsinx>
+   Problem 8 <2013/en/schnittpunkt>
+   Problem 9 <2013/en/inthalbkreis>
+   Problem 10 <2013/en/asymp>
+
+   Problem 1 <2014/en/extremum>
+   Problem 2 <2014/en/stammfunktionen>
+   Problem 3 <2014/en/sinusfunktionen>
+   Problem 4 <2014/en/beispielfunktionen>
+   Problem 5 <2014/en/qualitative_integrale>
+   Problem 6 <2014/en/wendepunkte>
+   Problem 7 <2014/en/rechteck>
+   Problem 8 <2014/en/wurzelfunktion>
+   Problem 9 <2014/en/gebrochenrational>
+
+   Problem 1 <2015/en/nullstellen_log>
+   Problem 2 <2015/en/funktionen>
+   Problem 3 <2015/en/sinus>
+   Problem 4 <2015/en/funktionseigenschaften>
+   Problem 5 <2015/en/funktionenschar>
+   
+   Problem 1 <2016/en/logarithmus>
+   Problem 2 <2016/en/ungerades_integral>
+   Problem 3 <2016/en/kubische_funktion>
+   Problem 4 <2016/en/log_quad>
+   Problem 5 <2016/en/beispielfunktion>
+   Problem 6 <2016/en/qualitatives_integral>

--- a/school/source/abitur/index_by_subject_geometry.rst
+++ b/school/source/abitur/index_by_subject_geometry.rst
@@ -1,0 +1,25 @@
+Bavarian final secondary-school examinations in mathematics
+===========================================================
+
+Geometry
+........
+
+.. toctree::
+   :maxdepth: 1
+
+   Problem 1 <2013/en/pyramide>
+   Problem 2 <2013/en/geraden>
+
+   Problem 1 <2014/en/prisma>
+   Problem 2 <2014/en/ebene>
+   Problem 3 <2014/en/quader>
+   Problem 4 <2014/en/kugel>
+   Problem 5 <2014/en/dreieck>
+   Problem 6 <2014/en/haus>
+
+   Problem 1 <2015/en/parallelogramm>
+   Problem 2 <2015/en/pyramide>
+
+   Problem 1 <2016/en/wuerfel>
+   Problem 2 <2016/en/geraden>
+   Problem 3 <2016/en/ebenen>

--- a/school/source/abitur/index_by_subject_geometry.rst
+++ b/school/source/abitur/index_by_subject_geometry.rst
@@ -7,19 +7,16 @@ Geometry
 .. toctree::
    :maxdepth: 1
 
-   Problem 1 <2013/en/pyramide>
-   Problem 2 <2013/en/geraden>
-
-   Problem 1 <2014/en/prisma>
-   Problem 2 <2014/en/ebene>
-   Problem 3 <2014/en/quader>
-   Problem 4 <2014/en/kugel>
-   Problem 5 <2014/en/dreieck>
-   Problem 6 <2014/en/haus>
-
-   Problem 1 <2015/en/parallelogramm>
-   Problem 2 <2015/en/pyramide>
-
-   Problem 1 <2016/en/wuerfel>
-   Problem 2 <2016/en/geraden>
-   Problem 3 <2016/en/ebenen>
+   Cube <2016/en/wuerfel>
+   Cuboid <2014/en/quader>
+   Geometry of a house <2014/en/haus>
+   Parallelogram <2015/en/parallelogramm>
+   Parallel planes <2016/en/ebenen>
+   Plane and sphere <2014/en/ebene>
+   Prism <2014/en/prisma>
+   Pyramid I <2013/en/pyramide>
+   Pyramid II <2015/en/pyramide>
+   Reflection at triangle <2014/en/dreieck>
+   Sphere <2014/en/kugel>
+   Straight lines I <2013/en/geraden>
+   Straight lines II <2016/en/geraden>

--- a/school/source/abitur/index_by_subject_stochastics.rst
+++ b/school/source/abitur/index_by_subject_stochastics.rst
@@ -7,24 +7,21 @@ Stochastics
 .. toctree::
    :maxdepth: 1
 
-   Problem 1 <2013/en/blutgruppe>
-   Problem 2 <2013/en/stoffwechsel>
-   Problem 3 <2013/en/gewinnspiel>
-   Problem 4 <2013/en/umfrage>
-   Problem 5 <2013/en/nullhypothese>
-   Problem 6 <2013/en/erwartungswert>
-
-   Problem 1 <2014/en/urne>
-   Problem 2 <2014/en/bernoulli>
-   Problem 3 <2014/en/zufallsgroesse>
-   Problem 4 <2014/en/baumdiagramm>
-   Problem 5 <2014/en/jim_studie>
-   Problem 6 <2014/en/supermarkt>
-   Problem 7 <2014/en/gluecksrad>
-
-   Problem 1 <2015/en/biathlon>
-   Problem 2 <2015/en/talkshow>
-
-   Problem 1 <2015/en/baumdiagramme>
-   Problem 2 <2015/en/muenzwurf>
-   Problem 3 <2015/en/pseminar>
+   Bernoulli process <2014/en/bernoulli>
+   Biathlon <2015/en/biathlon>
+   Blood types <2013/en/blutgruppe>
+   Bonus pictures <2014/en/supermarkt>
+   Coin toss <2016/en/muenzwurf>
+   Expectation value and variance <2013/en/erwartungswert>
+   Expectation value of a random variable <2014/en/zufallsgroesse>
+   JIM survey <2014/en/jim_studie>
+   Metabolic disorder <2013/en/stoffwechsel>
+   Null hypothesis <2013/en/nullhypothese>
+   Poll <2013/en/umfrage>
+   Prize draw <2013/en/gewinnspiel>
+   Seminar participants <2016/en/pseminar>
+   Talk show <2015/en/talkshow>
+   Tree diagram <2014/en/baumdiagramm>
+   Tree diagrams <2016/en/baumdiagramme>
+   Urns and balls <2014/en/urne>
+   Wheel of fortune <2014/en/gluecksrad>

--- a/school/source/abitur/index_by_subject_stochastics.rst
+++ b/school/source/abitur/index_by_subject_stochastics.rst
@@ -1,0 +1,30 @@
+Bavarian final secondary-school examinations in mathematics
+===========================================================
+
+Stochastics
+...........
+
+.. toctree::
+   :maxdepth: 1
+
+   Problem 1 <2013/en/blutgruppe>
+   Problem 2 <2013/en/stoffwechsel>
+   Problem 3 <2013/en/gewinnspiel>
+   Problem 4 <2013/en/umfrage>
+   Problem 5 <2013/en/nullhypothese>
+   Problem 6 <2013/en/erwartungswert>
+
+   Problem 1 <2014/en/urne>
+   Problem 2 <2014/en/bernoulli>
+   Problem 3 <2014/en/zufallsgroesse>
+   Problem 4 <2014/en/baumdiagramm>
+   Problem 5 <2014/en/jim_studie>
+   Problem 6 <2014/en/supermarkt>
+   Problem 7 <2014/en/gluecksrad>
+
+   Problem 1 <2015/en/biathlon>
+   Problem 2 <2015/en/talkshow>
+
+   Problem 1 <2015/en/baumdiagramme>
+   Problem 2 <2015/en/muenzwurf>
+   Problem 3 <2015/en/pseminar>

--- a/school/source/abitur/index_by_year.rst
+++ b/school/source/abitur/index_by_year.rst
@@ -1,6 +1,9 @@
 Bavarian final secondary-school examinations in mathematics
 ===========================================================
 
+Index by year
+.............
+
 .. toctree::
    :maxdepth: 2
 

--- a/school/source/index.rst
+++ b/school/source/index.rst
@@ -15,9 +15,10 @@ Problems in Mathematics with SageMath
 Here we present a set of problems from Bavarian *Abitur* solved with computer algebra. 
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
-   abitur/index.rst
+   by subject <abitur/index_by_subject.rst>
+   by year <abitur/index_by_year.rst>
 
 
 


### PR DESCRIPTION
This PR changes the index of Abitur problems purely based on the year to one offering an index by year and an index by subject. The subject index is restricted to the English version of the problems and solutions but could be extended to the German version if necessary. It should be noted, that in some cases the title describes the mathematical content of the problem while in other cases, in particular for the stochastics problems, the title often describes the application discussed in the problem.